### PR TITLE
Use single IOHIDManager for all PointingDevices

### DIFF
--- a/apps/consoleExample/consoleExample.cpp
+++ b/apps/consoleExample/consoleExample.cpp
@@ -84,7 +84,7 @@ main(int argc, char** argv) {
 
     // --- Transfer function --------------------------------------------------
 
-    func = TransferFunction::create(argc>3?argv[3]:"sigmoid:?debugLevel=2", input, output) ;
+    func = TransferFunction::create(argc>3?argv[3]:"system:?debugLevel=2", input, output) ;
 
     std::cout << std::endl << "Transfer function" << std::endl
         << "  " << func->getURI(true).asString() << std::endl

--- a/bindings/Node/libpointing/binding.gyp
+++ b/bindings/Node/libpointing/binding.gyp
@@ -14,10 +14,11 @@
       'conditions': [
 			['OS=="mac"', {
 				"link_settings": {
-				'libraries': [
-				   '-lpointing',
-				   '-L/usr/local/lib'
-				 ]},
+					'libraries': [
+					   '-lpointing',
+					   '-L/usr/local/lib'
+					 ]
+				 },
 				"include_dirs": [
 					'/usr/local/include',
 					"<!(node -e \"require('nan')\")"

--- a/building-and-packaging/mac/prepare
+++ b/building-and-packaging/mac/prepare
@@ -88,8 +88,7 @@ HEADERS = [
     # --------------------------------------------------------------
     "pointing/utils/osx/osxPlistUtils.h",
     "pointing/utils/osx/osxTimeUtils.h",
-    "pointing/input/osx/osxHIDInputDevice.h",
-    "pointing/input/osx/osxHIDPointingDevice.h",
+    "pointing/input/osx/osxPointingDevice.h",
     "pointing/input/osx/osxHIDUtils.h",
     "pointing/input/osx/osxPrivateMultitouchDevice.h",
     "pointing/input/osx/osxPrivateMultitouchSupport.h",
@@ -129,8 +128,7 @@ SOURCES = [
     # OS X specifics
     # --------------------------------------------------------------
     "pointing/utils/osx/osxPlistUtils.cpp",
-    "pointing/input/osx/osxHIDInputDevice.cpp",
-    "pointing/input/osx/osxHIDPointingDevice.cpp",
+    "pointing/input/osx/osxPointingDevice.cpp",
     "pointing/input/osx/osxHIDUtils.cpp",
     "pointing/input/osx/osxPrivateMultitouchDevice.cpp",
     "pointing/input/osx/osxPointingDeviceManager.cpp",

--- a/pointing/input/PointingDevice.cpp
+++ b/pointing/input/PointingDevice.cpp
@@ -22,7 +22,7 @@
 #include <pointing/input/DummyPointingDevice.h>
 
 #ifdef __APPLE__
-#include <pointing/input/osx/osxHIDPointingDevice.h>
+#include <pointing/input/osx/osxPointingDevice.h>
 #endif
 
 #ifdef _WIN32
@@ -124,7 +124,7 @@ namespace pointing {
 
 #ifdef __APPLE__
     if (anywilldo || uri.scheme=="osxhid")
-      return new osxHIDPointingDevice(uri) ;
+      return new osxPointingDevice(uri) ;
 #endif
 
 #ifdef _WIN32

--- a/pointing/input/PointingDeviceManager.cpp
+++ b/pointing/input/PointingDeviceManager.cpp
@@ -96,7 +96,7 @@ namespace pointing {
         }
     }
 
-    const URI PointingDeviceManager::anyToSpecific(const URI &anyURI) const
+    URI PointingDeviceManager::anyToSpecific(const URI &anyURI) const
     {
         if (anyURI.scheme != "any")
         {
@@ -117,7 +117,7 @@ namespace pointing {
                 return pdd.devURI;
             }
         }
-        std::cerr << "Warning: could not find a device with a given URI" << std::endl ;
+        //std::cerr << "Warning: could not find a device with a given URI" << std::endl ;
         return anyURI;
     }
 

--- a/pointing/input/PointingDeviceManager.h
+++ b/pointing/input/PointingDeviceManager.h
@@ -114,7 +114,7 @@ namespace pointing
          * @param anyURI URI with any scheme
          * @return platform-specific URI
          */
-        const URI anyToSpecific(const URI &anyURI) const;
+        URI anyToSpecific(const URI &anyURI) const;
 
         //static void destroy();
 

--- a/pointing/input/osx/osxPointingDevice.cpp
+++ b/pointing/input/osx/osxPointingDevice.cpp
@@ -26,11 +26,12 @@ namespace pointing {
 
   osxPointingDevice::osxPointingDevice(URI uri)
      :callback(NULL),callback_context(0),forced_cpi(-1.),
-      forced_hz(-1.),debugLevel(0),devRef(0)
+      forced_hz(-1.),debugLevel(0),devRef(0),seize(false)
   {
     URI::getQueryArg(uri.query, "cpi", &forced_cpi);
     URI::getQueryArg(uri.query, "hz", &forced_hz);
     URI::getQueryArg(uri.query, "debugLevel", &debugLevel);
+    URI::getQueryArg(uri.query, "seize", &seize);
 
     osxPointingDeviceManager *man = (osxPointingDeviceManager *)PointingDeviceManager::get();
 
@@ -43,20 +44,6 @@ namespace pointing {
     }
 
     man->addPointingDevice(this);
-    /*
-    if (debugLevel)
-    {
-      for (PointingDescriptorIterator it = man->begin(); it != man->end(); it++)
-      {
-          PointingDeviceDescriptor desc = *it;
-          bool match = ((URI(desc.devURI).path) == uri.path);
-          std::cout << (match ? "+ " : "  ") << desc.devURI
-               << " [" << std::hex << "vend:0x" << desc.vendorID
-               << ", prod:0x" << desc.productID
-               << std::dec << " - " << desc.name << " ]" << std::endl;
-      }
-    }
-    */
   }
 
   bool osxPointingDevice::isActive(void) const {

--- a/pointing/input/osx/osxPointingDevice.cpp
+++ b/pointing/input/osx/osxPointingDevice.cpp
@@ -1,0 +1,192 @@
+/* -*- mode: c++ -*-
+ *
+ * pointing/input/osx/osxPointingDevice.cpp --
+ *
+ * Initial software
+ * Authors: Nicolas Roussel, Izzatbek Mukhanov
+ * Copyright © Inria
+ *
+ * http://libpointing.org/
+ *
+ * This software may be used and distributed according to the terms of
+ * the GNU General Public License version 2 or any later version.
+ *
+ */
+
+#include <pointing/input/osx/osxPointingDevice.h>
+#include <pointing/input/osx/osxHIDUtils.h>
+#include <pointing/input/osx/osxPointingDeviceManager.h>
+
+namespace pointing {
+
+#define OSX_DEFAULT_VENDOR_ID     0
+#define OSX_DEFAULT_PRODUCT_ID    0
+#define OSX_DEFAULT_CPI           400.001
+#define OSX_DEFAULT_HZ            125.001
+
+  osxPointingDevice::osxPointingDevice(URI uri)
+     :callback(NULL),callback_context(0),forced_cpi(-1.),
+      forced_hz(-1.),debugLevel(0),devRef(0)
+  {
+    URI::getQueryArg(uri.query, "cpi", &forced_cpi);
+    URI::getQueryArg(uri.query, "hz", &forced_hz);
+    URI::getQueryArg(uri.query, "debugLevel", &debugLevel);
+
+    osxPointingDeviceManager *man = (osxPointingDeviceManager *)PointingDeviceManager::get();
+
+    if (uri.scheme == "any")
+      this->anyURI = uri;
+    else
+    {
+      this->uri = uri;
+      this->uri.generalize();
+    }
+
+    man->addPointingDevice(this);
+    /*
+    if (debugLevel)
+    {
+      for (PointingDescriptorIterator it = man->begin(); it != man->end(); it++)
+      {
+          PointingDeviceDescriptor desc = *it;
+          bool match = ((URI(desc.devURI).path) == uri.path);
+          std::cout << (match ? "+ " : "  ") << desc.devURI
+               << " [" << std::hex << "vend:0x" << desc.vendorID
+               << ", prod:0x" << desc.productID
+               << std::dec << " - " << desc.name << " ]" << std::endl;
+      }
+    }
+    */
+  }
+
+  bool osxPointingDevice::isActive(void) const {
+    return devRef != NULL;
+  }
+
+  URI osxPointingDevice::getURI(bool expanded, bool crossplatform) const
+  {
+    URI result = uri;
+
+    if (crossplatform)
+    {
+      if (!anyURI.asString().empty())
+        return anyURI;
+
+      result.scheme = "any";
+      int vendorID = getVendorID();
+      if (vendorID)
+        URI::addQueryArg(result.query, "vendor", vendorID) ;
+
+      int productID = getProductID();
+      if (productID)
+        URI::addQueryArg(result.query, "product", productID) ;
+    }
+
+    if (expanded || debugLevel)
+        URI::addQueryArg(result.query, "debugLevel", debugLevel);
+    if (expanded || forced_cpi > 0)
+        URI::addQueryArg(result.query, "cpi", getResolution());
+    if (expanded || forced_hz > 0)
+        URI::addQueryArg(result.query, "hz", getUpdateFrequency());
+
+    return result;
+  }
+
+  bool osxPointingDevice::isUSB(void)
+  {
+    return uri.path.find("/USB") == 0;
+  }
+
+  bool osxPointingDevice::isBluetooth(void)
+  {
+    return uri.path.find("/Bluetooth") == 0;
+  }
+
+  int osxPointingDevice::getVendorID(void) const
+  {
+    if (devRef)
+      return hidDeviceGetIntProperty(devRef, CFSTR(kIOHIDVendorIDKey));
+    return 0;
+  }
+
+  std::string osxPointingDevice::getVendor(void) const
+  {
+    if (devRef)
+      return hidDeviceGetStringProperty(devRef, CFSTR(kIOHIDManufacturerKey));
+    return 0;
+  }
+
+  int osxPointingDevice::getProductID(void) const
+  {
+    if (devRef)
+      return hidDeviceGetIntProperty(devRef, CFSTR(kIOHIDProductIDKey));
+    return 0;
+  }
+
+  std::string osxPointingDevice::getProduct(void) const
+  {
+    if (devRef)
+      return hidDeviceGetStringProperty(devRef, CFSTR(kIOHIDProductKey));
+    return 0;
+  }
+
+  double osxPointingDevice::getResolution(double *defval) const
+  {
+    if (forced_cpi > 0)
+      return forced_cpi;
+
+    if (devRef)
+    {
+      double result = -1.0;
+      result = hidGetPointingResolution(devRef);
+      if (result > 0)
+        return result;
+    }
+
+    if (defval)
+      return *defval;
+
+    return OSX_DEFAULT_CPI;
+  }
+
+  double osxPointingDevice::getUpdateFrequency(double *defval) const
+  {
+    if (forced_hz > 0)
+      return forced_hz;
+
+    if (devRef)
+    {
+      double result = -1;
+      result = 1.0 / hidGetReportInterval(devRef);
+      double estimated = estimatedUpdateFrequency();
+      if (result == 125. && estimated > 0.)
+        return estimated;
+      if (result > 0)
+        return result;
+      if (estimated > 0.)
+        return estimated;
+    }
+
+    if (defval)
+      return *defval;
+
+    return OSX_DEFAULT_HZ;
+  }
+
+  void osxPointingDevice::setDebugLevel(int level)
+  {
+    this->debugLevel = level;
+  }
+
+  void osxPointingDevice::setPointingCallback(PointingCallback cbck, void *ctx)
+  {
+    callback = cbck;
+    callback_context = ctx;
+  }
+
+  osxPointingDevice::~osxPointingDevice(void)
+  {
+    osxPointingDeviceManager *man = (osxPointingDeviceManager *)PointingDeviceManager::get();
+    man->removePointingDevice(this);
+  }
+}

--- a/pointing/input/osx/osxPointingDevice.h
+++ b/pointing/input/osx/osxPointingDevice.h
@@ -1,0 +1,65 @@
+/* -*- mode: c++ -*-
+ *
+ * pointing/input/osx/osxPointingDevice.h --
+ *
+ * Initial software
+ * Authors: Nicolas Roussel, Izzatbek Mukhanov
+ * Copyright © Inria
+ *
+ * http://libpointing.org/
+ *
+ * This software may be used and distributed according to the terms of
+ * the GNU General Public License version 2 or any later version.
+ *
+ */
+
+#ifndef osxPointingDevice_h
+#define osxPointingDevice_h
+
+#include <pointing/input/PointingDevice.h>
+#include <IOKit/hid/IOHIDManager.h>
+
+namespace pointing {
+
+  class osxPointingDevice : public PointingDevice
+  {
+    URI uri, anyURI;
+
+    friend class osxPointingDeviceManager;
+
+    PointingCallback callback;
+    void *callback_context;
+
+    double forced_cpi, forced_hz;
+
+    int debugLevel;
+
+    bool isUSB(void);
+    bool isBluetooth(void);
+
+    IOHIDDeviceRef devRef;
+
+  public:
+    osxPointingDevice(URI uri);
+
+    bool isActive(void) const;
+
+    int getVendorID(void) const;
+    std::string getVendor(void) const;
+    int getProductID(void) const;
+    std::string getProduct(void) const;
+
+    double getResolution(double *defval=0) const;
+    double getUpdateFrequency(double *defval=0) const;
+
+    URI getURI(bool expanded=false, bool crossplatform=false) const;
+
+    void setPointingCallback(PointingCallback callback, void *context=0);
+    void setDebugLevel(int level);
+
+    ~osxPointingDevice(void);
+
+  };
+}
+
+#endif

--- a/pointing/input/osx/osxPointingDevice.h
+++ b/pointing/input/osx/osxPointingDevice.h
@@ -38,6 +38,7 @@ namespace pointing {
     bool isBluetooth(void);
 
     IOHIDDeviceRef devRef;
+    bool seize;
 
   public:
     osxPointingDevice(URI uri);

--- a/pointing/input/osx/osxPointingDeviceManager.cpp
+++ b/pointing/input/osx/osxPointingDeviceManager.cpp
@@ -20,64 +20,193 @@
 
 #include <stdexcept>
 
-#define OSX_DEFAULT_VENDOR    0
-#define OSX_DEFAULT_PRODUCT   0
-#define OSX_DEFAULT_USAGEPAGE kHIDPage_GenericDesktop // Find any PointingDevice
-#define OSX_DEFAULT_USAGE     kHIDUsage_GD_Mouse      // Find any PointingDevice
+// FIXME Should I use CFRetain
+// seize
 
 namespace pointing {
 
-    void osxPointingDeviceManager::ConvertDevice(IOHIDDeviceRef inDevice, PointingDeviceDescriptor &desc)
-    {
-        desc.devURI = hidDeviceURI(inDevice).asString();
-        desc.name = hidDeviceName(inDevice);
-        desc.vendorID = hidDeviceGetIntProperty(inDevice, CFSTR(kIOHIDVendorIDKey));
-        desc.productID = hidDeviceGetIntProperty(inDevice, CFSTR(kIOHIDProductIDKey));
-    }
+#define USE_CURRENT_RUNLOOP 0
 
-    void osxPointingDeviceManager::AddDevice(void *sender, IOReturn, void *, IOHIDDeviceRef device)
-    {
-        osxPointingDeviceManager *self = (osxPointingDeviceManager *)sender;
-        PointingDeviceDescriptor desc;
-        ConvertDevice(device, desc);
-        self->descMap[device] = desc;
-        self->addDevice(desc);
-    }
+  void osxPointingDeviceManager::FillDescriptor(IOHIDDeviceRef devRef, PointingDeviceDescriptor &desc)
+  {
+    desc.devURI = hidDeviceURI(devRef).asString();
+    desc.name = hidDeviceName(devRef);
+    desc.vendorID = hidDeviceGetIntProperty(devRef, CFSTR(kIOHIDVendorIDKey));
+    desc.productID = hidDeviceGetIntProperty(devRef, CFSTR(kIOHIDProductIDKey));
+  }
 
-    void osxPointingDeviceManager::RemoveDevice(void *sender, IOReturn, void *, IOHIDDeviceRef device)
+  void osxPointingDeviceManager::convertAnyCandidates()
+  {
+    for (PointingList::iterator it = candidates.begin(); it != candidates.end(); it++)
     {
-        osxPointingDeviceManager *self = (osxPointingDeviceManager *)sender;
-        descMap_t::iterator it = self->descMap.find(device);
-        if (it != self->descMap.end())
+      osxPointingDevice *device = *it;
+      if (!device->anyURI.asString().empty())
+        device->uri = anyToSpecific(device->anyURI);
+    }
+  }
+
+  void osxPointingDeviceManager::matchCandidates()
+  {
+    convertAnyCandidates();
+    PointingList::iterator i = candidates.begin();
+    while (i != candidates.end())
+    {
+      osxPointingDevice *device = *i;
+      bool found = false;
+      for(devMap_t::iterator it = devMap.begin(); it != devMap.end(); it++)
+      {
+        PointingDeviceData *pdd = it->second;
+        // Found matching device
+        // Move it from candidates to devMap
+        if (pdd->desc.devURI == device->uri.asString())
         {
-            PointingDeviceDescriptor desc = it->second;
-            self->descMap.erase(it);
-            self->removeDevice(desc);
+          candidates.erase(i++);
+          pdd->pointingList.push_back(device);
+          device->devRef = pdd->devRef;
+          found = true;
+          break;
         }
+      }
+      if (!found)
+        i++;
     }
-
-    osxPointingDeviceManager::osxPointingDeviceManager()
+  }
+  /*
+  IOHIDDeviceRef osxPointingDeviceManager::findDevRefByURI(const URI &uri)
+  {
+    for(descMap_t::iterator it = descMap.begin(); it != descMap.end(); it++)
     {
-        manager = IOHIDManagerCreate(kCFAllocatorDefault, kIOHIDOptionsTypeNone) ;
-        if (!manager)
-            throw std::runtime_error("IOHIDManagerCreate failed") ;
-
-        int vendorID = OSX_DEFAULT_VENDOR ;
-        int productID = OSX_DEFAULT_PRODUCT ;
-        int primaryUsagePage = OSX_DEFAULT_USAGEPAGE ;
-        int primaryUsage = OSX_DEFAULT_USAGE ;
-
-        const char *plist = hidDeviceFromVendorProductUsagePageUsage(vendorID, productID,
-                                                            primaryUsagePage, primaryUsage).c_str() ;
-        CFMutableDictionaryRef device_match = (CFMutableDictionaryRef)getPropertyListFromXML(plist) ;
-        IOHIDManagerSetDeviceMatching(manager, device_match) ;
-
-        IOHIDManagerRegisterDeviceMatchingCallback(manager, AddDevice, this);
-        IOHIDManagerRegisterDeviceRemovalCallback(manager, RemoveDevice, this) ;
-        IOHIDManagerScheduleWithRunLoop(manager, CFRunLoopGetMain(), kCFRunLoopCommonModes) ;
-
-        IOOptionBits inOptions = kIOHIDOptionsTypeNone ;
-        if (IOHIDManagerOpen(manager, inOptions)!=kIOReturnSuccess)
-            throw std::runtime_error("IOHIDManagerOpen failed") ;
+      PointingDeviceData *pdd = it->second;
+      if (pdd->desc.devURI == uri.asString())
+        return it->first;
     }
+    return NULL;
+  }
+  */
+  void osxPointingDeviceManager::AddDevice(void *sender, IOReturn, void *, IOHIDDeviceRef devRef)
+  {
+    osxPointingDeviceManager *self = (osxPointingDeviceManager *)sender;
+    PointingDeviceData *pdd = new PointingDeviceData;
+    self->devMap[devRef] = pdd;
+    pdd->devRef = devRef;
+    FillDescriptor(devRef, pdd->desc);
+    self->addDevice(pdd->desc);
+
+    CFDataRef descriptor = (CFDataRef)IOHIDDeviceGetProperty(devRef, CFSTR(kIOHIDReportDescriptorKey));
+    if (descriptor) {
+      const UInt8 *bytes = CFDataGetBytePtr(descriptor);
+      CFIndex length = CFDataGetLength(descriptor);
+      if (!pdd->parser.setDescriptor(bytes, length))
+        std::cerr << "osxPointingDeviceManager::AddDevice: unable to parse the HID report descriptor" << std::endl;
+      else
+      {
+        IOHIDDeviceRegisterInputReportCallback(devRef, pdd->report, sizeof(pdd->report),
+                                               hidReportCallback, self);
+      }
+
+      //if (self->debugLevel > 1)
+      //{
+        std::cerr << "HID descriptors: [ " << std::flush ;
+        for (int i=0; i<length; ++i)
+          std::cerr << std::hex << std::setfill('0') << std::setw(2) << (int)bytes[i] << " " ;
+        std::cerr << "]" << std::endl ;
+      //}
+    }
+
+    self->matchCandidates();
+  }
+
+  void osxPointingDeviceManager::RemoveDevice(void *sender, IOReturn, void *, IOHIDDeviceRef devRef)
+  {
+    osxPointingDeviceManager *self = (osxPointingDeviceManager *)sender;
+    devMap_t::iterator it = self->devMap.find(devRef);
+    if (it != self->devMap.end())
+    {
+      PointingDeviceData *pdd = it->second;
+      self->removeDevice(pdd->desc);
+      for (PointingList::iterator it = pdd->pointingList.begin(); it != pdd->pointingList.end(); it++)
+      {
+        osxPointingDevice *device = *it;
+        device->devRef = NULL;
+        self->candidates.push_back(device);
+      }
+      delete pdd;
+      self->devMap.erase(it);
+    }
+    self->matchCandidates();
+  }
+
+  osxPointingDeviceManager::osxPointingDeviceManager()
+  {
+    manager = IOHIDManagerCreate(kCFAllocatorDefault, kIOHIDOptionsTypeNone) ;
+    if (!manager)
+      throw std::runtime_error("IOHIDManagerCreate failed");
+
+    const char *plist = hidDeviceFromVendorProductUsagePageUsage(0, 0, kHIDPage_GenericDesktop, kHIDUsage_GD_Mouse).c_str() ;
+    CFMutableDictionaryRef device_match = (CFMutableDictionaryRef)getPropertyListFromXML(plist) ;
+    IOHIDManagerSetDeviceMatching(manager, device_match) ;
+
+    IOHIDManagerRegisterDeviceMatchingCallback(manager, AddDevice, (void*)this) ;
+    IOHIDManagerRegisterDeviceRemovalCallback(manager, RemoveDevice, (void*)this) ;
+
+#if USE_CURRENT_RUNLOOP
+    CFRunLoopRef runLoop = CFRunLoopGetCurrent() ;
+    CFStringRef runLoopMode = kCFRunLoopDefaultMode ;
+#else
+    CFRunLoopRef runLoop = CFRunLoopGetMain() ;
+    CFStringRef runLoopMode = kCFRunLoopCommonModes ;
+#endif
+    IOHIDManagerScheduleWithRunLoop(manager, runLoop, runLoopMode) ;
+
+    if (IOHIDManagerOpen(manager, kIOHIDOptionsTypeNone)!=kIOReturnSuccess)
+      throw std::runtime_error("IOHIDManagerOpen failed") ;
+  }
+
+  void osxPointingDeviceManager::addPointingDevice(osxPointingDevice *device)
+  {
+    candidates.push_back(device);
+    matchCandidates();
+  }
+
+  void osxPointingDeviceManager::removePointingDevice(osxPointingDevice *device)
+  {
+    URI uri = device->getURI();
+    for(devMap_t::iterator it = devMap.begin(); it != devMap.end(); it++)
+    {
+      PointingDeviceData *pdd = it->second;
+      if (pdd->desc.devURI == uri.asString())
+      {
+        pdd->pointingList.remove(device);
+        break;
+      }
+    }
+    candidates.remove(device);
+  }
+
+  void osxPointingDeviceManager::hidReportCallback(void *context, IOReturn, void *dev, IOHIDReportType, uint32_t, uint8_t *report, CFIndex)
+  {
+    TimeStamp::inttime timestamp = TimeStamp::createAsInt();
+
+    osxPointingDeviceManager *self = (osxPointingDeviceManager*)context;
+    IOHIDDeviceRef devRef = (IOHIDDeviceRef)dev;
+
+    devMap_t::iterator it = self->devMap.find(devRef);
+
+    if (it != self->devMap.end())
+    {
+      PointingDeviceData *pdd = it->second;
+      if (pdd->parser.setReport(report))
+      {
+        int dx = 0, dy = 0, buttons = 0;
+        pdd->parser.getReportData(&dx, &dy, &buttons) ;
+        for (PointingList::iterator pit = pdd->pointingList.begin(); pit != pdd->pointingList.end(); pit++)
+        {
+          osxPointingDevice *device = *pit;
+          device->registerTimestamp(timestamp);
+          if (device->callback)
+            device->callback(device->callback_context, timestamp, dx, dy, buttons);
+        }
+      }
+    }
+  }
 }

--- a/pointing/input/osx/osxPointingDeviceManager.h
+++ b/pointing/input/osx/osxPointingDeviceManager.h
@@ -51,15 +51,13 @@ namespace pointing
     };
 
     PointingList candidates;
-    bool printList;
+    int debugLevel;
 
     typedef std::map<IOHIDDeviceRef, PointingDeviceData *> devMap_t;
 
     void convertAnyCandidates();
     void matchCandidates();
     void processMatching(PointingDeviceData *pdd, osxPointingDevice *device);
-
-    void printAll(bool debugLevel);
 
     // Map is needed because we cannot find all the information about removed device
     devMap_t devMap;

--- a/pointing/input/osx/osxPointingDeviceManager.h
+++ b/pointing/input/osx/osxPointingDeviceManager.h
@@ -31,14 +31,16 @@ namespace pointing
    * @brief The osxPointingDeviceManager class is the platform-specific
    * subclass of the PointingDeviceManager class.
    *
-   * There is no public members of this class, because all the functions are called by its parent
-   * which is also a friend of this class.
+   * There are no public members of this class, because all the functions are called by
+   * either its parent or osxPointingDevice which are friends of this class.
    */
   class osxPointingDeviceManager : public PointingDeviceManager
   {
+    friend class PointingDeviceManager;
+    friend class osxPointingDevice;
+
     typedef std::list<osxPointingDevice *> PointingList;
 
-    // TODO maybe move it to another class
     struct PointingDeviceData
     {
       PointingDeviceDescriptor desc;
@@ -49,15 +51,15 @@ namespace pointing
     };
 
     PointingList candidates;
+    bool printList;
 
-    friend class PointingDeviceManager;
-    friend class osxPointingDevice;
     typedef std::map<IOHIDDeviceRef, PointingDeviceData *> devMap_t;
 
     void convertAnyCandidates();
-    //IOHIDDeviceRef findDevRefByURI(const URI &uri);
-
     void matchCandidates();
+    void processMatching(PointingDeviceData *pdd, osxPointingDevice *device);
+
+    void printAll(bool debugLevel);
 
     // Map is needed because we cannot find all the information about removed device
     devMap_t devMap;
@@ -65,7 +67,6 @@ namespace pointing
     IOHIDManagerRef manager;
     static void AddDevice(void *context, IOReturn /*result*/, void *sender, IOHIDDeviceRef devRef);
     static void RemoveDevice(void *context, IOReturn /*result*/, void *sender, IOHIDDeviceRef devRef);
-    static void FillDescriptor(IOHIDDeviceRef devRef, PointingDeviceDescriptor &desc);
 
     osxPointingDeviceManager();
     ~osxPointingDeviceManager() {}

--- a/pointing/input/windows/winHIDDeviceDispatcher.cpp
+++ b/pointing/input/windows/winHIDDeviceDispatcher.cpp
@@ -150,8 +150,7 @@ namespace pointing {
       case GIDC_ARRIVAL:
       {
         self->existingDevices.insert(((HANDLE)lParam));
-        RID_DEVICE_INFO deviceinfo;
-        self->manager->registerMouseDevice((HANDLE)lParam, deviceinfo);
+        self->manager->registerMouseDevice((HANDLE)lParam);
         self->activateDevice((HANDLE)lParam, true);
         break;
       }

--- a/pointing/input/windows/winPointingDevice.cpp
+++ b/pointing/input/windows/winPointingDevice.cpp
@@ -83,10 +83,11 @@ namespace pointing {
 
         if (uri.scheme == "any")
         {
-          anyURI = uri;
-          uri = man->anyToSpecific(anyURI);
+          this->anyURI = uri;
+          this->uri = man->anyToSpecific(anyURI);
         }
-        this->uri = uri;
+        else
+          this->uri = uri;
 
         ATTRIB_FROM_URI(uri.query, handle);
         man->dispatcher->addPointingDevice((HANDLE)handle, this);
@@ -114,14 +115,16 @@ namespace pointing {
     }
 
     double
-    winPointingDevice::getResolution(double *defval) const {
+    winPointingDevice::getResolution(double *defval) const
+    {
       if (forced_cpi > 0)
         return forced_cpi;
       return defval ? *defval : WIN_DEFAULT_CPI ;
     }
 
     double
-    winPointingDevice::getUpdateFrequency(double *defval) const {
+    winPointingDevice::getUpdateFrequency(double *defval) const
+    {
       if (forced_hz > 0)
         return forced_hz;
       double estimated = estimatedUpdateFrequency();
@@ -131,15 +134,15 @@ namespace pointing {
     }
 
     void
-    winPointingDevice::setPointingCallback(PointingCallback cbck, void *ctx) {
-      // Thread-issue, to guarantee that the callback will be call with a not yet
-      // initialized context we first set the context then the callback.
+    winPointingDevice::setPointingCallback(PointingCallback cbck, void *ctx)
+    {
       callback_context = ctx ; 
       callback = cbck ;
     }
 
     URI
-    winPointingDevice::getURI(bool expanded, bool crossplatform) const {
+    winPointingDevice::getURI(bool expanded, bool crossplatform) const
+    {
       URI result;
 
       if (crossplatform)
@@ -156,15 +159,15 @@ namespace pointing {
       if (expanded || debugLevel)
           URI::addQueryArg(result.query, "debugLevel", debugLevel);
       if (expanded || forced_cpi > 0)
-          URI::addQueryArg(result.query, "cpi", forced_cpi);
+          URI::addQueryArg(result.query, "cpi", getResolution());
       if (expanded || forced_hz > 0)
-          URI::addQueryArg(result.query, "hz", forced_hz);
+          URI::addQueryArg(result.query, "hz", getUpdateFrequency());
 
       return result;
     }
 
-    bool
-    winPointingDevice::isActive(void) const {
+    bool winPointingDevice::isActive(void) const
+    {
         return active;
     }
 
@@ -188,7 +191,8 @@ namespace pointing {
         return this->product;
     }
 
-    winPointingDevice::~winPointingDevice(void) {
+    winPointingDevice::~winPointingDevice(void)
+    {
       winPointingDeviceManager *man = (winPointingDeviceManager *)PointingDeviceManager::get();
       man->dispatcher->removePointingDevice((HANDLE)handle, this);
       //DestroyWindow(msghwnd_);

--- a/pointing/input/windows/winPointingDeviceManager.cpp
+++ b/pointing/input/windows/winPointingDeviceManager.cpp
@@ -49,7 +49,7 @@ namespace pointing
         removeDevice(desc);
     }
 
-    void winPointingDeviceManager::registerMouseDevice(HANDLE h, RID_DEVICE_INFO& /*deviceinfo*/)
+    void winPointingDeviceManager::registerMouseDevice(HANDLE h)
     {
         PointingDeviceDescriptor desc;
         if (ConvertDevice(h, desc))

--- a/pointing/input/windows/winPointingDeviceManager.h
+++ b/pointing/input/windows/winPointingDeviceManager.h
@@ -26,7 +26,7 @@ namespace pointing
         friend class winHIDDeviceDispatcher;
         bool ConvertDevice(HANDLE h, PointingDeviceDescriptor &desc);
 
-        void registerMouseDevice(HANDLE, RID_DEVICE_INFO&);
+        void registerMouseDevice(HANDLE);
         void unregisterMouseDevice(HANDLE h);
 
         winHIDDeviceDispatcher *dispatcher;

--- a/pointing/pointing.pro
+++ b/pointing/pointing.pro
@@ -73,8 +73,9 @@ include(../pointing-xorg/pointing-xorg.pri)
 macx {
   HEADERS += $$HERE/utils/osx/osxTimeUtils.h \
              $$HERE/utils/osx/osxPlistUtils.h \
-             $$HERE/input/osx/osxHIDInputDevice.h \
-             $$HERE/input/osx/osxHIDPointingDevice.h \
+             $$HERE/input/osx/osxHIDInputDevice.h \ # TODO remove this
+             $$HERE/input/osx/osxHIDPointingDevice.h \ # TODO remove this
+             $$HERE/input/osx/osxPointingDevice.h \
              $$HERE/input/osx/osxHIDUtils.h \
              $$HERE/input/osx/osxPrivateMultitouchDevice.h \
              $$HERE/input/osx/osxPrivateMultitouchSupport.h \
@@ -83,8 +84,9 @@ macx {
              $$HERE/output/osx/osxDisplayDeviceManager.h \
              $$HERE/transferfunctions/osx/osxSystemPointerAcceleration.h
   SOURCES += $$HERE/utils/osx/osxPlistUtils.cpp \
-             $$HERE/input/osx/osxHIDInputDevice.cpp \
-             $$HERE/input/osx/osxHIDPointingDevice.cpp \
+             $$HERE/input/osx/osxHIDInputDevice.cpp \ # TODO remove this
+             $$HERE/input/osx/osxHIDPointingDevice.cpp \ # TODO remove this
+             $$HERE/input/osx/osxPointingDevice.cpp \
              $$HERE/input/osx/osxHIDUtils.cpp \
              $$HERE/input/osx/osxPrivateMultitouchDevice.cpp \
              $$HERE/input/osx/osxPointingDeviceManager.cpp \

--- a/pointing/pointing.pro
+++ b/pointing/pointing.pro
@@ -73,8 +73,6 @@ include(../pointing-xorg/pointing-xorg.pri)
 macx {
   HEADERS += $$HERE/utils/osx/osxTimeUtils.h \
              $$HERE/utils/osx/osxPlistUtils.h \
-             $$HERE/input/osx/osxHIDInputDevice.h \ # TODO remove this
-             $$HERE/input/osx/osxHIDPointingDevice.h \ # TODO remove this
              $$HERE/input/osx/osxPointingDevice.h \
              $$HERE/input/osx/osxHIDUtils.h \
              $$HERE/input/osx/osxPrivateMultitouchDevice.h \
@@ -84,8 +82,6 @@ macx {
              $$HERE/output/osx/osxDisplayDeviceManager.h \
              $$HERE/transferfunctions/osx/osxSystemPointerAcceleration.h
   SOURCES += $$HERE/utils/osx/osxPlistUtils.cpp \
-             $$HERE/input/osx/osxHIDInputDevice.cpp \ # TODO remove this
-             $$HERE/input/osx/osxHIDPointingDevice.cpp \ # TODO remove this
              $$HERE/input/osx/osxPointingDevice.cpp \
              $$HERE/input/osx/osxHIDUtils.cpp \
              $$HERE/input/osx/osxPrivateMultitouchDevice.cpp \

--- a/pointing/utils/HIDReportParser.cpp
+++ b/pointing/utils/HIDReportParser.cpp
@@ -21,30 +21,18 @@
 
 using namespace std;
 
+namespace pointing
+{
 // FIXME: Wheel, Z
 
-struct MouseReport
-{
-    int reportId;
-    int size;
-    int dxPos;
-    int dyPos;
-
-    // dMask is mask that can read bits which do not correspond to entire bytes
-    // for example: for 12 bits this will be 0xFFF
-    int dMask;
-    int min;
-    int max;
-    int buttonsPos;
-
-    MouseReport():reportId(0),size(0),dxPos(0),dyPos(0),dMask(0),min(0),max(0),buttonsPos(-1) {}
-};
+HIDReportParser::HIDReportParser()
+  :lastRepCount(0),lastRepSize(0),curRepInfo(0),debugLevel(0) { }
 
 HIDReportParser::HIDReportParser(unsigned char *desc, int size, int debugLevel):
-  lastRepCount(0),lastRepSize(0),report(0),debugLevel(debugLevel)
+  lastRepCount(0),lastRepSize(0),curRepInfo(0),debugLevel(debugLevel)
 {
-    if (size)
-        setDescriptor(desc, size);
+  if (size)
+    setDescriptor(desc, size);
 }
 
 void HIDReportParser::parseItem(const HIDItem &item)
@@ -170,7 +158,7 @@ bool HIDReportParser::findCorrectReport()
 {
     for (map<int, MouseReport>::iterator it = reportMap.begin(); it != reportMap.end(); it++)
     {
-        //cout << it->first << endl;
+      //cout << it->first << endl;
         MouseReport rep = it->second;
         if (rep.dxPos && rep.dyPos)
         {
@@ -185,7 +173,7 @@ bool HIDReportParser::findCorrectReport()
             }
             if (debugLevel)
             {
-        cerr << "    HIDReportParser: report ID #" << curRepInfo->reportId << " - "
+                cerr << "    HIDReportParser: report ID #" << curRepInfo->reportId << " - "
                      << "buttons: " << curRepInfo->buttonsPos
                      << ", dx: " << curRepInfo->dxPos
                      << ", dy: " << curRepInfo->dyPos
@@ -249,4 +237,5 @@ bool HIDReportParser::getReportData(int *dx, int *dy, int *buttons) const
         *dy = *dy - curRepInfo->dMask - 1;
     *buttons = *(report + (curRepInfo->buttonsPos / 8)) >> (curRepInfo->buttonsPos % 8) & 7;
     return true;
+}
 }

--- a/pointing/utils/HIDReportParser.cpp
+++ b/pointing/utils/HIDReportParser.cpp
@@ -26,10 +26,10 @@ namespace pointing
   // FIXME: Wheel, Z
 
   HIDReportParser::HIDReportParser()
-    :lastRepCount(0),lastRepSize(0),curRepInfo(0),debugLevel(0) { }
+    :lastRepCount(0),lastRepSize(0),curRepInfo(0),report(0),debugLevel(0) { }
 
   HIDReportParser::HIDReportParser(unsigned char *desc, int size, int debugLevel):
-    lastRepCount(0),lastRepSize(0),curRepInfo(0),debugLevel(debugLevel)
+    lastRepCount(0),lastRepSize(0),curRepInfo(0),report(0),debugLevel(debugLevel)
   {
     if (size)
       setDescriptor(desc, size);

--- a/pointing/utils/HIDReportParser.h
+++ b/pointing/utils/HIDReportParser.h
@@ -21,18 +21,33 @@
 #include <iostream>
 #include <map>
 
-using namespace pointing;
-
-struct MouseReport;
-
-/**
- * @brief The HIDReportParser class is very specific HID Report parser
- * which attempts to find only button and relative mouse displacement positions
- * in a given HID descriptor and according to that descriptor outputs the found
- * values in given HID reports
- */
-class HIDReportParser
+namespace pointing
 {
+  /**
+   * @brief The HIDReportParser class is very specific HID Report parser
+   * which attempts to find only button and relative mouse displacement positions
+   * in a given HID descriptor and according to that descriptor outputs the found
+   * values in given HID reports
+   */
+  class HIDReportParser
+  {
+    struct MouseReport
+    {
+      int reportId;
+      int size;
+      int dxPos;
+      int dyPos;
+
+      // dMask is mask that can read bits which do not correspond to entire bytes
+      // for example: for 12 bits this will be 0xFFF
+      int dMask;
+      int min;
+      int max;
+      int buttonsPos;
+
+      MouseReport():reportId(0),size(0),dxPos(0),dyPos(0),dMask(0),min(0),max(0),buttonsPos(-1) {}
+    };
+
     unsigned int lastUsage, parentUsage, lastUsagePage;
     unsigned int lastRepCount, lastRepSize; // If one of them is not present, we pick the last available
     std::map<int, MouseReport> reportMap;
@@ -50,7 +65,12 @@ class HIDReportParser
     // Find the report which contains relative X and Y
     bool findCorrectReport();
 
-public:
+    // TODO Implement copy constructor which copies
+    // report and curRepInfo correctly
+    HIDReportParser(HIDReportParser const&);
+
+  public:
+    HIDReportParser();
     HIDReportParser(unsigned char *desc, int size, int debugLevel=0);
     ~HIDReportParser();
 
@@ -82,6 +102,6 @@ public:
      * @return True if read successfully False otherwise
      */
     bool getReportData(int *dx, int *dy, int *buttons) const;
-};
-
+  };
+}
 #endif // HID_REPORT_PARSER_H


### PR DESCRIPTION
Made changes:
- Now osxPointingDeviceManager is used to manage all the IOHIDDevices with a single IOHIDManager.
- osxPointingDevice subclass of PointingDevice is added.
- osxHIDPointingDevice and osxHIDInputDevice are left untouched. If needed, we can get back to the previous implementation replacing osxPointingDevice by osxHIDPointingDevice in PointingDevice.cpp.
