### PR TITLE
Refactor linuxPointingDevice

### DIFF
--- a/bindings/Node/libpointing/pointing/npointingdevicemanager.cc
+++ b/bindings/Node/libpointing/pointing/npointingdevicemanager.cc
@@ -43,8 +43,9 @@ static callbackMap_t callbackMap = callbackMap_t();
 
 void createDescObject(Local<Object> &descObj, const PointingDeviceDescriptor &pdd)
 {
-  Nan::Set(descObj, Nan::New("devURI").ToLocalChecked(), Nan::New(pdd.devURI).ToLocalChecked());
-  Nan::Set(descObj, Nan::New("name").ToLocalChecked(), Nan::New(pdd.name).ToLocalChecked());
+  Nan::Set(descObj, Nan::New("devURI").ToLocalChecked(), Nan::New(pdd.devURI.asString()).ToLocalChecked());
+  Nan::Set(descObj, Nan::New("vendor").ToLocalChecked(), Nan::New(pdd.vendor).ToLocalChecked());
+  Nan::Set(descObj, Nan::New("product").ToLocalChecked(), Nan::New(pdd.product).ToLocalChecked());
   Nan::Set(descObj, Nan::New("vendorID").ToLocalChecked(), Nan::New(pdd.vendorID));
   Nan::Set(descObj, Nan::New("productID").ToLocalChecked(), Nan::New(pdd.productID));
 }

--- a/bindings/Node/server/server.js
+++ b/bindings/Node/server/server.js
@@ -36,20 +36,26 @@ function uriIsOK(deviceDescriptor) {
   return true;
 }
 
-function logDevice(desc, wasAdded) {
+function logPointingDevice(desc, wasAdded) {
+  console.log(new Date().toString() + ': device ' + (wasAdded ? 'added' : 'removed'));
+  console.log('\twith URI: ' + desc.devURI);
+  console.log('\twith vendor: ' + desc.vendor + ' and product: ' + desc.product);
+  console.log('\twith vendorID: ' + desc.vendorID + ' and productID: ' + desc.productID);
+}
+
+function logDisplayDevice(desc, wasAdded) {
   console.log(new Date().toString() + ': device ' + (wasAdded ? 'added' : 'removed'));
   console.log('\twith name: ' + desc.name + ' and URI: ' + desc.devURI);
-  console.log('\twith vendorID: ' + desc.vendorID + ' and productID: ' + desc.productID);
 }
 
 manager.addDeviceUpdateCallback(function(desc, wasAdded) {
   io.emit('deviceUpdateCallback', desc, wasAdded);
-  logDevice(desc, wasAdded);
+  logPointingDevice(desc, wasAdded);
 });
 
 dManager.addDeviceUpdateCallback(function(desc, wasAdded) {
   io.emit('displayUpdateCallback', desc, wasAdded);
-  logDevice(desc, wasAdded);
+  logDisplayDevice(desc, wasAdded);
 });
 
 io.on('connection', function(socket) {

--- a/building-and-packaging/linux/prepare
+++ b/building-and-packaging/linux/prepare
@@ -74,7 +74,7 @@ HEADERS = [
     # --------------------------------------------------------------
     # Linux specifics
     # --------------------------------------------------------------
-    "pointing/input/linux/linuxHIDPointingDevice.h",
+    "pointing/input/linux/linuxPointingDevice.h",
     "pointing/output/linux/xorgDisplayDevice.h",
     "pointing/transferfunctions/linux/xorgSystemPointerAcceleration.h",
     "pointing/input/linux/linuxPointingDeviceManager.h",
@@ -110,7 +110,7 @@ SOURCES = [
     # --------------------------------------------------------------
     # Linux specifics
     # --------------------------------------------------------------
-    "pointing/input/linux/linuxHIDPointingDevice.cpp",
+    "pointing/input/linux/linuxPointingDevice.cpp",
     "pointing/output/linux/xorgDisplayDevice.cpp",
     "pointing/transferfunctions/linux/xorgSystemPointerAcceleration.cpp",
     "pointing/input/linux/linuxPointingDeviceManager.cpp",

--- a/pointing/input/PointingDevice.cpp
+++ b/pointing/input/PointingDevice.cpp
@@ -30,7 +30,7 @@
 #endif
 
 #ifdef __linux__
-#include <pointing/input/linux/linuxHIDPointingDevice.h>
+#include <pointing/input/linux/linuxPointingDevice.h>
 #endif
 
 #include <stdexcept>
@@ -130,7 +130,7 @@ namespace pointing {
 
 #ifdef __linux__
     if (anywilldo || uri.scheme=="hidraw")
-      return new linuxHIDPointingDevice(uri);
+      return new linuxPointingDevice(uri);
 #endif
 
     if (uri.scheme=="dummy")

--- a/pointing/input/PointingDeviceManager.cpp
+++ b/pointing/input/PointingDeviceManager.cpp
@@ -58,7 +58,7 @@ namespace pointing {
 
     bool PointingDeviceDescriptor::operator < (const PointingDeviceDescriptor& rhs) const
     {
-        return devURI < rhs.devURI;
+        return devURI.asString() < rhs.devURI.asString();
     }
 
     // To use the set of the CallbackInfos

--- a/pointing/input/PointingDeviceManager.h
+++ b/pointing/input/PointingDeviceManager.h
@@ -24,16 +24,16 @@ namespace pointing
 {
     struct PointingDeviceDescriptor
     {
-        std::string devURI;
-        std::string name;
-        //std::string vendor;
-        //std::string product;
+        URI devURI;
 
         int vendorID;
         int productID;
 
-        PointingDeviceDescriptor(std::string devURI = "", std::string name = "")
-            :devURI(devURI),name(name),vendorID(0),productID(0)//,vendor("???"),product("???")
+        std::string vendor;
+        std::string product;
+
+        PointingDeviceDescriptor()
+            :vendorID(0),productID(0),vendor("???"),product("???")
         { }
 
         // To use set of PointingDeviceDescriptors

--- a/pointing/input/linux/linuxPointingDevice.cpp
+++ b/pointing/input/linux/linuxPointingDevice.cpp
@@ -102,9 +102,9 @@ namespace pointing {
   // --------------------------------------------------------------------------
 */
   linuxPointingDevice::linuxPointingDevice(URI uri):
-    uri(uri),vendorID(0),productID(0),seize(0),debugLevel(0),
-    callback(NULL),callback_context(NULL),active(false),
-    forced_cpi(-1.), forced_hz(-1.)
+    uri(uri),forced_cpi(-1.),forced_hz(-1.),
+    vendorID(0),productID(0),seize(0),debugLevel(0),
+    callback(NULL),callback_context(NULL),active(false)
   {
     URI::getQueryArg(uri.query, "cpi", &forced_cpi);
     URI::getQueryArg(uri.query, "hz", &forced_hz);
@@ -235,5 +235,7 @@ namespace pointing {
 
   linuxPointingDevice::~linuxPointingDevice()
   {
+    linuxPointingDeviceManager *man = (linuxPointingDeviceManager *)PointingDeviceManager::get();
+    man->removePointingDevice(this);
   }
 }

--- a/pointing/input/linux/linuxPointingDevice.cpp
+++ b/pointing/input/linux/linuxPointingDevice.cpp
@@ -15,92 +15,12 @@
 
 #include <pointing/input/linux/linuxPointingDevice.h>
 #include <pointing/input/linux/linuxPointingDeviceManager.h>
-//#include <unistd.h>
-
-/*
-#include <X11/Xatom.h>
-#include <X11/extensions/XInput.h>
-
-#include <string.h>
-#include <stdio.h>
-#include <stdlib.h>
-#include <sstream>
-#include <linux/input.h>
-#include <linux/hidraw.h>
-#include <sys/ioctl.h>
-#include <fcntl.h>
-
-#include <iostream>
-#include <stdexcept>
-*/
 
 namespace pointing {
 
   #define XORG_DEFAULT_CPI       400.0
   #define XORG_DEFAULT_HZ        125.0
-/*
-  XDeviceInfo*
-  find_device_info(Display	*display,
-                   char		*name,
-                   Bool		only_extended)
-  {
-    XDeviceInfo	*devices;
-    XDeviceInfo *found = NULL;
-    int		loop;
-    int		num_devices;
-    int		len = strlen(name);
-    Bool	is_id = True;
-    XID		id = (XID)-1;
 
-    for(loop=0; loop<len; loop++) {
-      if (!isdigit(name[loop])) {
-        is_id = False;
-        break;
-      }
-    }
-
-    if (is_id) {
-      id = atoi(name);
-    }
-
-    devices = XListInputDevices(display, &num_devices);
-
-    for(loop=0; loop<num_devices; loop++) {
-      if ((!only_extended || (devices[loop].use >= IsXExtensionDevice)) &&
-          ((!is_id && strcmp(devices[loop].name, name) == 0) ||
-           (is_id && devices[loop].id == id))) {
-        if (found) {
-          fprintf(stderr,
-                  "Warning: There are multiple devices named '%s'.\n"
-                  "To ensure the correct one is selected, please use "
-                  "the device ID instead.\n\n", name);
-          return NULL;
-        } else {
-          found = &devices[loop];
-        }
-      }
-    }
-    return found;
-  }
-
-  static inline int str16ToInt(std::string value)
-  {
-      std::stringstream ss;
-      ss << std::hex << value;
-      int result;
-      ss >> result;
-      return result;
-  }
-
-  static inline std::string
-  bustype2string(int bustype) {
-    const char *names[] = {"???", "PCI", "ISAPNP", "USB", "HIL", "BLUETOOTH", "VIRTUAL"} ;
-    if (bustype<0 || bustype>BUS_VIRTUAL) return names[0] ;
-    return names[bustype] ;
-  }
-
-  // --------------------------------------------------------------------------
-*/
   linuxPointingDevice::linuxPointingDevice(URI uri):
     uri(uri),forced_cpi(-1.),forced_hz(-1.),
     vendorID(0),productID(0),seize(0),debugLevel(0),
@@ -124,35 +44,6 @@ namespace pointing {
 
     man->addPointingDevice(this);
   }
-/*
-  void linuxPointingDevice::enableDevice(bool value)
-  {
-    Display	*dpy = XOpenDisplay(0);
-    std::string fullName = vendor + " " + product;
-    XDeviceInfo *info = find_device_info(dpy, (char *)fullName.c_str(), False);
-    if (!info)
-    {
-      fprintf(stderr, "unable to find the device\n");
-      return;
-    }
-
-    XDevice *dev = XOpenDevice(dpy, info->id);
-    if (!dev)
-    {
-      fprintf(stderr, "unable to open the device\n");
-      return;
-    }
-
-    Atom prop = XInternAtom(dpy, "Device Enabled", False);
-
-    unsigned char data = value;
-
-    XChangeDeviceProperty(dpy, dev, prop, XA_INTEGER, 8, PropModeReplace,
-                          &data, 1);
-    XCloseDevice(dpy, dev);
-    XCloseDisplay(dpy);
-  }
-*/
 
   bool linuxPointingDevice::isActive(void) const {
     return active;

--- a/pointing/input/linux/linuxPointingDevice.cpp
+++ b/pointing/input/linux/linuxPointingDevice.cpp
@@ -1,0 +1,238 @@
+/* -*- mode: c++ -*-
+ *
+ * pointing/input/linux/linuxPointingDevice.cpp --
+ *
+ * Initial software
+ * Authors: Nicolas Roussel, Izzat Mukhanov
+ * Copyright © Inria
+ *
+ * http://libpointing.org/
+ *
+ * This software may be used and distributed according to the terms of
+ * the GNU General Public License version 2 or any later version.
+ *
+ */
+
+#include <pointing/input/linux/linuxPointingDevice.h>
+#include <pointing/input/linux/linuxPointingDeviceManager.h>
+//#include <unistd.h>
+
+/*
+#include <X11/Xatom.h>
+#include <X11/extensions/XInput.h>
+
+#include <string.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <sstream>
+#include <linux/input.h>
+#include <linux/hidraw.h>
+#include <sys/ioctl.h>
+#include <fcntl.h>
+
+#include <iostream>
+#include <stdexcept>
+*/
+
+namespace pointing {
+
+  #define XORG_DEFAULT_CPI       400.0
+  #define XORG_DEFAULT_HZ        125.0
+/*
+  XDeviceInfo*
+  find_device_info(Display	*display,
+                   char		*name,
+                   Bool		only_extended)
+  {
+    XDeviceInfo	*devices;
+    XDeviceInfo *found = NULL;
+    int		loop;
+    int		num_devices;
+    int		len = strlen(name);
+    Bool	is_id = True;
+    XID		id = (XID)-1;
+
+    for(loop=0; loop<len; loop++) {
+      if (!isdigit(name[loop])) {
+        is_id = False;
+        break;
+      }
+    }
+
+    if (is_id) {
+      id = atoi(name);
+    }
+
+    devices = XListInputDevices(display, &num_devices);
+
+    for(loop=0; loop<num_devices; loop++) {
+      if ((!only_extended || (devices[loop].use >= IsXExtensionDevice)) &&
+          ((!is_id && strcmp(devices[loop].name, name) == 0) ||
+           (is_id && devices[loop].id == id))) {
+        if (found) {
+          fprintf(stderr,
+                  "Warning: There are multiple devices named '%s'.\n"
+                  "To ensure the correct one is selected, please use "
+                  "the device ID instead.\n\n", name);
+          return NULL;
+        } else {
+          found = &devices[loop];
+        }
+      }
+    }
+    return found;
+  }
+
+  static inline int str16ToInt(std::string value)
+  {
+      std::stringstream ss;
+      ss << std::hex << value;
+      int result;
+      ss >> result;
+      return result;
+  }
+
+  static inline std::string
+  bustype2string(int bustype) {
+    const char *names[] = {"???", "PCI", "ISAPNP", "USB", "HIL", "BLUETOOTH", "VIRTUAL"} ;
+    if (bustype<0 || bustype>BUS_VIRTUAL) return names[0] ;
+    return names[bustype] ;
+  }
+
+  // --------------------------------------------------------------------------
+*/
+  linuxPointingDevice::linuxPointingDevice(URI uri):
+    uri(uri),vendorID(0),productID(0),seize(0),debugLevel(0),
+    callback(NULL),callback_context(NULL),active(false)
+  {
+    URI::getQueryArg(uri.query, "cpi", &forced_cpi);
+    URI::getQueryArg(uri.query, "hz", &forced_hz);
+    URI::getQueryArg(uri.query, "debugLevel", &debugLevel);
+    URI::getQueryArg(uri.query, "seize", &seize);
+
+    linuxPointingDeviceManager *man = (linuxPointingDeviceManager *)PointingDeviceManager::get();
+
+    if (uri.scheme == "any")
+    {
+      anyURI = PointingDeviceManager::generalizeAny(uri);
+      URI::getQueryArg(uri.query, "vendor", &vendorID);
+      URI::getQueryArg(uri.query, "product", &productID);
+    }
+    else
+      this->uri.generalize();
+
+    man->addPointingDevice(this);
+  }
+/*
+  void linuxPointingDevice::enableDevice(bool value)
+  {
+    Display	*dpy = XOpenDisplay(0);
+    std::string fullName = vendor + " " + product;
+    XDeviceInfo *info = find_device_info(dpy, (char *)fullName.c_str(), False);
+    if (!info)
+    {
+      fprintf(stderr, "unable to find the device\n");
+      return;
+    }
+
+    XDevice *dev = XOpenDevice(dpy, info->id);
+    if (!dev)
+    {
+      fprintf(stderr, "unable to open the device\n");
+      return;
+    }
+
+    Atom prop = XInternAtom(dpy, "Device Enabled", False);
+
+    unsigned char data = value;
+
+    XChangeDeviceProperty(dpy, dev, prop, XA_INTEGER, 8, PropModeReplace,
+                          &data, 1);
+    XCloseDevice(dpy, dev);
+    XCloseDisplay(dpy);
+  }
+*/
+
+  bool linuxPointingDevice::isActive(void) const {
+    return active;
+  }
+
+  int linuxPointingDevice::getVendorID() const
+  {
+      return vendorID;
+  }
+
+  std::string linuxPointingDevice::getVendor() const
+  {
+      return vendor;
+  }
+
+  int linuxPointingDevice::getProductID() const
+  {
+      return productID;
+  }
+
+  std::string linuxPointingDevice::getProduct() const
+  {
+      return product;
+  }
+
+  double linuxPointingDevice::getResolution(double *defval) const {
+    if (forced_cpi > 0) return forced_cpi;
+    return defval ? *defval : XORG_DEFAULT_CPI;
+  }
+
+  double linuxPointingDevice::getUpdateFrequency(double *defval) const {
+    if (forced_hz > 0) return forced_hz;
+    double estimated = estimatedUpdateFrequency();
+    if (estimated > 0.)
+      return estimated;
+    return defval ? *defval : XORG_DEFAULT_HZ;
+  }
+
+  URI linuxPointingDevice::getURI(bool expanded, bool crossplatform) const
+  {
+    URI result = uri;
+    if (crossplatform)
+    {
+      if (anyURI.scheme.size())
+        result = anyURI;
+      else
+      {
+        int vendorID = getVendorID();
+        if (vendorID)
+          URI::addQueryArg(result.query, "vendor", vendorID) ;
+
+        int productID = getProductID();
+        if (productID)
+          URI::addQueryArg(result.query, "product", productID) ;
+      }
+    }
+
+    if (expanded || seize)
+        URI::addQueryArg(result.query, "seize", seize);
+    if (expanded || debugLevel)
+        URI::addQueryArg(result.query, "debugLevel", debugLevel);
+    if (expanded || forced_cpi > 0)
+        URI::addQueryArg(result.query, "cpi", getResolution());
+    if (expanded || forced_hz > 0)
+        URI::addQueryArg(result.query, "hz", getUpdateFrequency());
+
+    return result;
+  }
+
+  void linuxPointingDevice::setPointingCallback(PointingCallback cbck, void *ctx)
+  {
+    callback = cbck;
+    callback_context = ctx;
+  }
+
+  void linuxPointingDevice::setDebugLevel(int level)
+  {
+    debugLevel = level;
+  }
+
+  linuxPointingDevice::~linuxPointingDevice()
+  {
+  }
+}

--- a/pointing/input/linux/linuxPointingDevice.cpp
+++ b/pointing/input/linux/linuxPointingDevice.cpp
@@ -103,7 +103,8 @@ namespace pointing {
 */
   linuxPointingDevice::linuxPointingDevice(URI uri):
     uri(uri),vendorID(0),productID(0),seize(0),debugLevel(0),
-    callback(NULL),callback_context(NULL),active(false)
+    callback(NULL),callback_context(NULL),active(false),
+    forced_cpi(-1.), forced_hz(-1.)
   {
     URI::getQueryArg(uri.query, "cpi", &forced_cpi);
     URI::getQueryArg(uri.query, "hz", &forced_hz);

--- a/pointing/input/linux/linuxPointingDevice.h
+++ b/pointing/input/linux/linuxPointingDevice.h
@@ -35,8 +35,6 @@ namespace pointing {
     void *callback_context;
 
     std::string vendor, product;
-
-    void enableDevice(bool value);
     bool active;
 
   public:

--- a/pointing/input/linux/linuxPointingDevice.h
+++ b/pointing/input/linux/linuxPointingDevice.h
@@ -1,0 +1,68 @@
+/* -*- mode: c++ -*-
+ *
+ * pointing/input/linux/linuxPointingDevice.h --
+ *
+ * Initial software
+ * Authors: Nicolas Roussel, Izzat Mukhanov
+ * Copyright © Inria
+ *
+ * http://libpointing.org/
+ *
+ * This software may be used and distributed according to the terms of
+ * the GNU General Public License version 2 or any later version.
+ *
+ */
+
+#ifndef linuxPointingDevice_h
+#define linuxPointingDevice_h
+
+#include <pointing/input/PointingDevice.h>
+
+namespace pointing {
+
+  class linuxPointingDevice : public PointingDevice
+  {
+    friend class linuxPointingDeviceManager;
+    URI uri, anyURI;
+    
+    double forced_cpi, forced_hz;
+
+    int vendorID, productID;
+    bool seize;
+
+    int debugLevel;
+    PointingCallback callback;
+    void *callback_context;
+
+    std::string vendor, product;
+
+    void enableDevice(bool value);
+    bool active;
+
+  public:
+  
+    linuxPointingDevice(URI uri) ;
+
+    bool isActive(void) const;
+
+    int getVendorID(void) const;
+    std::string getVendor(void) const;
+    int getProductID(void) const;
+    std::string getProduct(void) const;
+
+    double getResolution(double *defval=0) const;
+    double getUpdateFrequency(double *defval=0) const;
+
+    URI getURI(bool expanded=false, bool crossplatform=false) const;
+
+    void setPointingCallback(PointingCallback callback, void *context=0);
+
+    void setDebugLevel(int level);
+
+    ~linuxPointingDevice();
+
+  } ;
+
+}
+
+#endif

--- a/pointing/input/linux/linuxPointingDeviceManager.cpp
+++ b/pointing/input/linux/linuxPointingDeviceManager.cpp
@@ -15,93 +15,112 @@
 
 #include <pointing/input/linux/linuxPointingDeviceManager.h>
 
+#include <pointing/utils/Base64.h>
 #include <string.h>
 #include <stdio.h>
 #include <stdlib.h>
+#include <unistd.h>
 
 #include <pointing/utils/URI.h>
 
+#include <linux/input.h>
 #include <linux/hidraw.h>
+#include <sys/ioctl.h>
+#include <fcntl.h>
+
 #include <iostream>
 #include <stdexcept>
 
 using namespace std;
 
 namespace pointing {
+
+#define MAX(X, Y)           (((X) > (Y)) ? (X) : (Y))
   
     string uriStringFromDevice(struct udev_device *hiddev)
     {
-        const char *devnode = udev_device_get_devnode(hiddev);
-        URI devUri;
-        devUri.scheme = "hidraw" ;
-        devUri.path = devnode ;
-        return devUri.asString();
+      const char *devnode = udev_device_get_devnode(hiddev);
+      URI devUri;
+      devUri.scheme = "hidraw";
+      devUri.path = devnode;
+      return devUri.asString();
     }
     
     static inline string sysattr2string(struct udev_device *dev, const char *key, const char *defval=0)
     {
-        const char *value = udev_device_get_sysattr_value(dev, key);
-        return value ? value : (defval ? defval : string()) ;
+      const char *value = udev_device_get_sysattr_value(dev, key);
+      return value ? value : (defval ? defval : string());
     }
 
     static inline int sysattr2int(struct udev_device *dev, const char *key, int defval=0)
     {
-        const char *value = udev_device_get_sysattr_value(dev, key);
-        return value ? strtol(value, NULL, 16) : defval;
+      const char *value = udev_device_get_sysattr_value(dev, key);
+      return value ? strtol(value, NULL, 16) : defval;
     }
-    
+
+    bool checkDev(int devID)
+    {
+      fd_set rfds;
+      FD_ZERO(&rfds);
+      FD_SET(devID, &rfds);
+      int nbready = select(devID + 1, &rfds, NULL, NULL, 0);
+      pthread_testcancel();
+      if (nbready == -1)
+        perror("linuxPointingDevice::eventloop");
+      return FD_ISSET(devID, &rfds);
+    }
+
     void *linuxPointingDeviceManager::eventloop(void *context)
     {
-        pthread_setcancelstate(PTHREAD_CANCEL_ENABLE, NULL) ;
-        pthread_setcanceltype(PTHREAD_CANCEL_DEFERRED, NULL) ;
+      pthread_setcancelstate(PTHREAD_CANCEL_ENABLE, NULL) ;
+      pthread_setcanceltype(PTHREAD_CANCEL_DEFERRED, NULL) ;
 
-        linuxPointingDeviceManager *self = (linuxPointingDeviceManager*)context ;
-       
-        udev_monitor_enable_receiving(self->monitor) ;
-        int monfd = udev_monitor_get_fd(self->monitor) ;
-        while (true) {
-          fd_set rfds;
-          FD_ZERO(&rfds) ;
-          FD_SET(monfd, &rfds) ;
-          int nbready = select(monfd + 1, &rfds, NULL, NULL, 0) ;
-          pthread_testcancel() ;
-          if (nbready==-1)
-	        perror("linuxPointingDeviceManager::eventloop") ;
-          else {
-	        if (FD_ISSET(monfd, &rfds)) self->monitor_readable() ;
-          }
+      linuxPointingDeviceManager *self = (linuxPointingDeviceManager*)context ;
+
+      udev_monitor_enable_receiving(self->monitor) ;
+      int monfd = udev_monitor_get_fd(self->monitor) ;
+      while (true)
+      {
+        if (checkDev(monfd))
+          self->monitor_readable();
+        for(devMap_t::iterator it = self->devMap.begin(); it != self->devMap.end(); it++)
+        {
+          if (checkDev(it->second->devID))
+            self->hid_readable(it->second);
         }
-        return 0 ;
+      }
+      return 0 ;
     }
 
     linuxPointingDeviceManager::linuxPointingDeviceManager()
     {
-        udev = udev_new() ;
-        if (!udev)
-          throw runtime_error("linuxPointingDeviceManager: udev_new failed") ;
+      udev = udev_new();
+      if (!udev)
+        throw runtime_error("linuxPointingDeviceManager: udev_new failed");
 
-        struct udev_enumerate *enumerate = udev_enumerate_new(udev) ;
-        udev_enumerate_add_match_subsystem(enumerate, "hidraw") ;
-        udev_enumerate_scan_devices(enumerate) ;
-        struct udev_list_entry *devices = udev_enumerate_get_list_entry(enumerate) ;
-        struct udev_list_entry *dev_list_entry ;
-        udev_list_entry_foreach(dev_list_entry, devices) {
-          const char *path = udev_list_entry_get_name(dev_list_entry) ;
-          struct udev_device *dev = udev_device_new_from_syspath(udev, path) ;
-          //cerr << uriStringFromDevice(dev) << endl;
-          checkFoundDevice(dev);
-          udev_device_unref(dev);
-        }
-        udev_enumerate_unref(enumerate);
-        
-        monitor = udev_monitor_new_from_netlink(udev, "udev") ;
-        udev_monitor_filter_add_match_subsystem_devtype(monitor, "hidraw", NULL) ;
-        
-        int ret = pthread_create(&thread, NULL, eventloop, (void*)this) ;
-        if (ret < 0) {
-          perror("linuxPointingDeviceManager::linuxPointingDeviceManager") ;
-          throw runtime_error("linuxPointingDeviceManager: pthread_create failed") ;    
-        }
+      struct udev_enumerate *enumerate = udev_enumerate_new(udev);
+      udev_enumerate_add_match_subsystem(enumerate, "hidraw");
+      udev_enumerate_scan_devices(enumerate);
+      struct udev_list_entry *devices = udev_enumerate_get_list_entry(enumerate);
+      struct udev_list_entry *dev_list_entry;
+      udev_list_entry_foreach(dev_list_entry, devices) {
+        const char *path = udev_list_entry_get_name(dev_list_entry);
+        struct udev_device *dev = udev_device_new_from_syspath(udev, path);
+        //cerr << uriStringFromDevice(dev) << endl;
+        checkFoundDevice(dev);
+        udev_device_unref(dev);
+      }
+      udev_enumerate_unref(enumerate);
+
+      monitor = udev_monitor_new_from_netlink(udev, "udev");
+      udev_monitor_filter_add_match_subsystem_devtype(monitor, "hidraw", NULL);
+
+      int ret = pthread_create(&thread, NULL, eventloop, (void*)this);
+      if (ret < 0)
+      {
+        perror("linuxPointingDeviceManager::linuxPointingDeviceManager") ;
+        throw runtime_error("linuxPointingDeviceManager: pthread_create failed") ;
+      }
     }
 
     void linuxPointingDeviceManager::monitor_readable(void)
@@ -119,47 +138,181 @@ namespace pointing {
         }
     }
   
-    void linuxPointingDeviceManager::ConvertDevice(struct udev_device *hiddev, struct udev_device *usbdev, PointingDeviceDescriptor &desc)
+    void linuxPointingDeviceManager::fillDescriptorInfo(struct udev_device *hiddev, struct udev_device *usbdev, PointingDeviceDescriptor &desc)
     {
-        string uri = uriStringFromDevice(hiddev);
-        desc.devURI = uri;
-        string vendor = sysattr2string(usbdev, "product", "????") ;
-        string product = sysattr2string(usbdev, "manufacturer", "????") ;
+      desc.devURI = URI(uriStringFromDevice(hiddev));
+      desc.vendor = sysattr2string(usbdev, "product", "????");
+      desc.product = sysattr2string(usbdev, "manufacturer", "????");
+      desc.vendorID = sysattr2int(usbdev, "idVendor");
+      desc.productID = sysattr2int(usbdev, "idProduct");
+    }
 
-        int vendorID = sysattr2int(usbdev, "idVendor") ;
-        int productID = sysattr2int(usbdev, "idProduct") ;
+    void linuxPointingDeviceManager::convertAnyCandidates()
+    {
+      for (PointingList::iterator it = candidates.begin(); it != candidates.end(); it++)
+      {
+        linuxPointingDevice *device = *it;
+        if (!device->anyURI.asString().empty())
+          device->uri = anyToSpecific(device->anyURI);
+      }
+    }
 
-        //string serial = sysattr2string(hiddev, "serial", "????") ;
-        //cout << serial << endl;
-        desc.name = vendor + " " + product;
-        desc.vendorID = vendorID;
-        desc.productID = productID;
+    void linuxPointingDeviceManager::matchCandidates()
+    {
+      convertAnyCandidates();
+      for(devMap_t::iterator it = devMap.begin(); it != devMap.end(); it++)
+      {
+        PointingDeviceData *pdd = it->second;
+
+        PointingList::iterator i = candidates.begin();
+        while (i != candidates.end())
+        {
+          linuxPointingDevice *device = *i;
+          // Found matching device
+          // Move it from candidates to devMap
+          if (pdd->desc.devURI == device->uri.asString())
+          {
+            candidates.erase(i++);
+            processMatching(pdd, device);
+          }
+          else
+            i++;
+        }
+      }
+    }
+
+    void linuxPointingDeviceManager::processMatching(PointingDeviceData *pdd, linuxPointingDevice *device)
+    {
+      pdd->pointingList.push_back(device);
+      device->active = true;
+      device->productID = pdd->desc.productID;
+      device->vendorID = pdd->desc.vendorID;
+      device->vendor = pdd->desc.vendor;
+      device->product = pdd->desc.product;
+    }
+
+    int linuxPointingDeviceManager::readHIDDescriptor(int devID, HIDReportParser *parser)
+    {
+      int descSize = 0;
+      int res = ioctl(devID, HIDIOCGRDESCSIZE, &descSize);
+      if (res < 0) {
+        std::cerr << "linuxPointingDevice::checkFoundDevice: unable to open HID device" << std::endl ;
+        return 0;
+      }
+      if (debugLevel > 0)
+        std::cerr << "  descriptor size: " << descSize << std::endl ;
+      struct hidraw_report_descriptor descriptor ;
+      descriptor.size = descSize ;
+      res = ioctl(devID, HIDIOCGRDESC, &descriptor) ;
+      if (!parser->setDescriptor(descriptor.value, descSize))
+        std::cerr << "linuxPointingDevice::checkFoundDevice: unable to parse the HID report descriptor" << std::endl;
+      if (res < 0) {
+        perror("linuxPointingDevice::checkFoundDevice") ;
+        return 0;
+      } else {
+        if (debugLevel > 1) {
+          std::cerr << "  descriptor (" << descriptor.size << " bytes): " ;
+          std::string reportstring ;
+          reportstring.assign((const char *)descriptor.value, descriptor.size) ;
+          std::cerr << Base64::encode(reportstring) << std::endl ;
+        }
+      }
+      return parser->getReportLength();
     }
 
     void linuxPointingDeviceManager::checkFoundDevice(struct udev_device *hiddev)
     {
-        struct udev_device *usbdev = udev_device_get_parent_with_subsystem_devtype(hiddev, "usb", "usb_device") ;
-        if (!usbdev) return ;
+      struct udev_device *usbdev = udev_device_get_parent_with_subsystem_devtype(hiddev, "usb", "usb_device") ;
+      if (!usbdev) return ;
 
-        // std::cout << "Device added" << std::endl;
-        PointingDeviceDescriptor desc;
-        ConvertDevice(hiddev, usbdev, desc);
-        //std::cerr << "osxPointingDeviceManager::AddDevice: adding " << desc.deviceURI.asString() << std::endl ;
+      const char *devnode = udev_device_get_devnode(hiddev);
+      int devID = open(devnode, O_RDONLY);
+      if (devID == -1) {
+        std::cerr << "linuxPointingDeviceManager::checkFoundDevice: unable to open HID device" << std::endl ;
+        return ;
+      }
+      PointingDeviceData *pdd = new PointingDeviceData;
+      devMap[devnode] = pdd;
+      pdd->devID = devID;
+      fillDescriptorInfo(hiddev, usbdev, pdd->desc);
+      addDevice(pdd->desc);
+      matchCandidates();
 
-        addDevice(desc);
-  }
+      pdd->reportLength = readHIDDescriptor(devID, &pdd->parser);
+      //if (self->debugLevel > 0)
+      //  printDevice(devRef, pdd->pointingList.size());
+    }
 
-    void linuxPointingDeviceManager::checkLostDevice(struct udev_device *dev)
+    void linuxPointingDeviceManager::checkLostDevice(struct udev_device *hiddev)
     {
-        PointingDeviceDescriptor desc(uriStringFromDevice(dev));
-        removeDevice(desc);
+      const char *devnode = udev_device_get_devnode(hiddev);
+      devMap_t::iterator it = devMap.find(devnode);
+      if (it != devMap.end())
+      {
+        PointingDeviceData *pdd = it->second;
+        removeDevice(pdd->desc);
+        close(pdd->devID);
+        for (PointingList::iterator it = pdd->pointingList.begin(); it != pdd->pointingList.end(); it++)
+        {
+          linuxPointingDevice *device = *it;
+          device->active = false;
+          candidates.push_back(device);
+        }
+        delete pdd;
+        devMap.erase(it);
+      }
+      matchCandidates();
+    }
+
+    void linuxPointingDeviceManager::addPointingDevice(linuxPointingDevice *device)
+    {
+      debugLevel = MAX(debugLevel, device->debugLevel);
+      candidates.push_back(device);
+      matchCandidates();
+    }
+
+    void linuxPointingDeviceManager::hid_readable(PointingDeviceData *pdd)
+    {
+      TimeStamp::inttime now = TimeStamp::createAsInt() ;
+      unsigned char *report = new unsigned char[pdd->reportLength];
+      int32_t length = read(pdd->devID, report, pdd->reportLength);
+      pdd->parser.setReport(report);
+      delete report;
+
+      if (length > 0)
+      {
+        int dx=0, dy=0, buttons=0;
+        pdd->parser.getReportData(&dx, &dy, &buttons);
+        for (PointingList::iterator it = pdd->pointingList.begin(); it != pdd->pointingList.end(); it++)
+        {
+          linuxPointingDevice *device = *it;
+          device->registerTimestamp(now);
+          if (device->callback)
+            device->callback(device->callback_context, now, dx, dy, buttons);
+        }
+      }
+    }
+
+    void linuxPointingDeviceManager::removePointingDevice(linuxPointingDevice *device)
+    {
+      URI uri = device->getURI();
+      for(devMap_t::iterator it = devMap.begin(); it != devMap.end(); it++)
+      {
+        PointingDeviceData *pdd = it->second;
+        if (pdd->desc.devURI == uri.asString())
+        {
+          pdd->pointingList.remove(device);
+          break;
+        }
+      }
+      candidates.remove(device);
     }
 
     linuxPointingDeviceManager::~linuxPointingDeviceManager()
     {
-        if (pthread_cancel(thread) < 0)
-            perror("linuxPointingDeviceManager::~linuxPointingDeviceManager");
-        udev_monitor_unref(monitor);
-        udev_unref(udev);
+      if (pthread_cancel(thread) < 0)
+        perror("linuxPointingDeviceManager::~linuxPointingDeviceManager");
+      udev_monitor_unref(monitor);
+      udev_unref(udev);
     }
 }

--- a/pointing/input/linux/linuxPointingDeviceManager.cpp
+++ b/pointing/input/linux/linuxPointingDeviceManager.cpp
@@ -40,387 +40,387 @@ namespace pointing {
 
 #define MAX(X, Y)           (((X) > (Y)) ? (X) : (Y))
 
-    URI uriFromDevice(struct udev_device *hiddev)
-    {
-      const char *devnode = udev_device_get_devnode(hiddev);
-      URI devUri;
-      devUri.scheme = "hidraw";
-      devUri.path = devnode;
-      return devUri;
+  URI uriFromDevice(struct udev_device *hiddev)
+  {
+    const char *devnode = udev_device_get_devnode(hiddev);
+    URI devUri;
+    devUri.scheme = "hidraw";
+    devUri.path = devnode;
+    return devUri;
+  }
+
+  static inline string sysattr2string(struct udev_device *dev, const char *key, const char *defval=0)
+  {
+    const char *value = udev_device_get_sysattr_value(dev, key);
+    return value ? value : (defval ? defval : string());
+  }
+
+  static inline int sysattr2int(struct udev_device *dev, const char *key, int defval=0)
+  {
+    const char *value = udev_device_get_sysattr_value(dev, key);
+    return value ? strtol(value, NULL, 16) : defval;
+  }
+
+  bool checkDev(int devID)
+  {
+    fd_set rfds;
+    FD_ZERO(&rfds);
+    FD_SET(devID, &rfds);
+    int nbready = select(devID + 1, &rfds, NULL, NULL, 0);
+    pthread_testcancel();
+    if (nbready == -1)
+      perror("linuxPointingDevice::eventloop");
+    return FD_ISSET(devID, &rfds);
+  }
+
+
+  XDeviceInfo*
+  find_device_info(Display	*display,
+                   char		*name,
+                   Bool		only_extended)
+  {
+    XDeviceInfo	*devices;
+    XDeviceInfo *found = NULL;
+    int		loop;
+    int		num_devices;
+    int		len = strlen(name);
+    Bool	is_id = True;
+    XID		id = (XID)-1;
+
+    for(loop=0; loop<len; loop++) {
+      if (!isdigit(name[loop])) {
+        is_id = False;
+        break;
+      }
     }
 
-    static inline string sysattr2string(struct udev_device *dev, const char *key, const char *defval=0)
-    {
-      const char *value = udev_device_get_sysattr_value(dev, key);
-      return value ? value : (defval ? defval : string());
+    if (is_id) {
+      id = atoi(name);
     }
 
-    static inline int sysattr2int(struct udev_device *dev, const char *key, int defval=0)
-    {
-      const char *value = udev_device_get_sysattr_value(dev, key);
-      return value ? strtol(value, NULL, 16) : defval;
-    }
+    devices = XListInputDevices(display, &num_devices);
 
-    bool checkDev(int devID)
-    {
-      fd_set rfds;
-      FD_ZERO(&rfds);
-      FD_SET(devID, &rfds);
-      int nbready = select(devID + 1, &rfds, NULL, NULL, 0);
-      pthread_testcancel();
-      if (nbready == -1)
-        perror("linuxPointingDevice::eventloop");
-      return FD_ISSET(devID, &rfds);
-    }
-
-
-    XDeviceInfo*
-    find_device_info(Display	*display,
-                     char		*name,
-                     Bool		only_extended)
-    {
-      XDeviceInfo	*devices;
-      XDeviceInfo *found = NULL;
-      int		loop;
-      int		num_devices;
-      int		len = strlen(name);
-      Bool	is_id = True;
-      XID		id = (XID)-1;
-
-      for(loop=0; loop<len; loop++) {
-        if (!isdigit(name[loop])) {
-          is_id = False;
-          break;
+    for(loop=0; loop<num_devices; loop++) {
+      if ((!only_extended || (devices[loop].use >= IsXExtensionDevice)) &&
+          ((!is_id && strcmp(devices[loop].name, name) == 0) ||
+           (is_id && devices[loop].id == id))) {
+        if (found) {
+          fprintf(stderr,
+                  "Warning: There are multiple devices named '%s'.\n"
+                  "To ensure the correct one is selected, please use "
+                  "the device ID instead.\n\n", name);
+          return NULL;
+        } else {
+          found = &devices[loop];
         }
       }
+    }
+    return found;
+  }
 
-      if (is_id) {
-        id = atoi(name);
-      }
+  void linuxPointingDeviceManager::enableDevice(bool value, std::string fullName)
+  {
+    Display	*dpy = XOpenDisplay(0);
+    XDeviceInfo *info = find_device_info(dpy, (char *)fullName.c_str(), False);
+    if (!info)
+    {
+      fprintf(stderr, "unable to find the device\n");
+      return;
+    }
 
-      devices = XListInputDevices(display, &num_devices);
+    XDevice *dev = XOpenDevice(dpy, info->id);
+    if (!dev)
+    {
+      fprintf(stderr, "unable to open the device\n");
+      return;
+    }
 
-      for(loop=0; loop<num_devices; loop++) {
-        if ((!only_extended || (devices[loop].use >= IsXExtensionDevice)) &&
-            ((!is_id && strcmp(devices[loop].name, name) == 0) ||
-             (is_id && devices[loop].id == id))) {
-          if (found) {
-            fprintf(stderr,
-                    "Warning: There are multiple devices named '%s'.\n"
-                    "To ensure the correct one is selected, please use "
-                    "the device ID instead.\n\n", name);
-            return NULL;
-          } else {
-            found = &devices[loop];
-          }
+    Atom prop = XInternAtom(dpy, "Device Enabled", False);
+
+    unsigned char data = value;
+
+    XChangeDeviceProperty(dpy, dev, prop, XA_INTEGER, 8, PropModeReplace,
+                          &data, 1);
+    XCloseDevice(dpy, dev);
+    XCloseDisplay(dpy);
+  }
+
+  void *linuxPointingDeviceManager::eventloop(void *context)
+  {
+    pthread_setcancelstate(PTHREAD_CANCEL_ENABLE, NULL) ;
+    pthread_setcanceltype(PTHREAD_CANCEL_DEFERRED, NULL) ;
+
+    linuxPointingDeviceManager *self = (linuxPointingDeviceManager*)context ;
+
+    struct udev_enumerate *enumerate = udev_enumerate_new(self->udev);
+    udev_enumerate_add_match_subsystem(enumerate, "hidraw");
+    udev_enumerate_scan_devices(enumerate);
+
+    struct udev_list_entry *devices = udev_enumerate_get_list_entry(enumerate);
+    struct udev_list_entry *dev_list_entry;
+    udev_list_entry_foreach(dev_list_entry, devices) {
+      const char *path = udev_list_entry_get_name(dev_list_entry);
+      struct udev_device *dev = udev_device_new_from_syspath(self->udev, path);
+      self->checkFoundDevice(dev);
+      udev_device_unref(dev);
+    }
+    udev_enumerate_unref(enumerate);
+
+    udev_monitor_enable_receiving(self->monitor) ;
+    int monfd = udev_monitor_get_fd(self->monitor) ;
+    while (true)
+    {
+      if (checkDev(monfd))
+        self->monitor_readable();
+    }
+    return 0 ;
+  }
+
+  void *linuxPointingDeviceManager::checkReports(void *context)
+  {
+    pthread_setcancelstate(PTHREAD_CANCEL_ENABLE, NULL) ;
+    pthread_setcanceltype(PTHREAD_CANCEL_DEFERRED, NULL) ;
+
+    PointingDeviceData *pdd = (PointingDeviceData *)context;
+    linuxPointingDeviceManager *self = (linuxPointingDeviceManager *)PointingDeviceManager::get();
+
+    while (true)
+    {
+      if (checkDev(pdd->devID))
+        self->hid_readable(pdd);
+    }
+    return 0 ;
+  }
+
+  linuxPointingDeviceManager::linuxPointingDeviceManager()
+  {
+    udev = udev_new();
+    if (!udev)
+      throw runtime_error("linuxPointingDeviceManager: udev_new failed");
+
+    monitor = udev_monitor_new_from_netlink(udev, "udev");
+    udev_monitor_filter_add_match_subsystem_devtype(monitor, "hidraw", NULL);
+
+    int ret = pthread_create(&thread, NULL, eventloop, (void*)this);
+    if (ret < 0)
+    {
+      perror("linuxPointingDeviceManager::linuxPointingDeviceManager") ;
+      throw runtime_error("linuxPointingDeviceManager: pthread_create failed") ;
+    }
+  }
+
+  void linuxPointingDeviceManager::monitor_readable(void)
+  {
+      struct udev_device *dev = udev_monitor_receive_device(monitor) ;
+      if (dev)
+      {
+        const char *action = udev_device_get_action(dev) ;
+        if (!strcmp(action,"add")) {
+          checkFoundDevice(dev) ;
+        } else if (!strcmp(action,"remove")) {
+          checkLostDevice(dev) ;
         }
+        udev_device_unref(dev) ;
       }
-      return found;
-    }
+  }
 
-    void linuxPointingDeviceManager::enableDevice(bool value, std::string fullName)
+  void linuxPointingDeviceManager::fillDescriptorInfo(struct udev_device *hiddev, struct udev_device *usbdev, PointingDeviceDescriptor &desc)
+  {
+    desc.devURI = uriFromDevice(hiddev);
+    desc.vendor = sysattr2string(usbdev, "product", "????");
+    desc.product = sysattr2string(usbdev, "manufacturer", "????");
+    desc.vendorID = sysattr2int(usbdev, "idVendor");
+    desc.productID = sysattr2int(usbdev, "idProduct");
+  }
+
+  void linuxPointingDeviceManager::convertAnyCandidates()
+  {
+    for (PointingList::iterator it = candidates.begin(); it != candidates.end(); it++)
     {
-      Display	*dpy = XOpenDisplay(0);
-      XDeviceInfo *info = find_device_info(dpy, (char *)fullName.c_str(), False);
-      if (!info)
-      {
-        fprintf(stderr, "unable to find the device\n");
-        return;
-      }
-
-      XDevice *dev = XOpenDevice(dpy, info->id);
-      if (!dev)
-      {
-        fprintf(stderr, "unable to open the device\n");
-        return;
-      }
-
-      Atom prop = XInternAtom(dpy, "Device Enabled", False);
-
-      unsigned char data = value;
-
-      XChangeDeviceProperty(dpy, dev, prop, XA_INTEGER, 8, PropModeReplace,
-                            &data, 1);
-      XCloseDevice(dpy, dev);
-      XCloseDisplay(dpy);
+      linuxPointingDevice *device = *it;
+      if (!device->anyURI.asString().empty())
+        device->uri = anyToSpecific(device->anyURI);
     }
+  }
 
-    void *linuxPointingDeviceManager::eventloop(void *context)
+  void linuxPointingDeviceManager::matchCandidates()
+  {
+    convertAnyCandidates();
+    for(devMap_t::iterator it = devMap.begin(); it != devMap.end(); it++)
     {
-      pthread_setcancelstate(PTHREAD_CANCEL_ENABLE, NULL) ;
-      pthread_setcanceltype(PTHREAD_CANCEL_DEFERRED, NULL) ;
+      PointingDeviceData *pdd = it->second;
 
-      linuxPointingDeviceManager *self = (linuxPointingDeviceManager*)context ;
-
-      struct udev_enumerate *enumerate = udev_enumerate_new(self->udev);
-      udev_enumerate_add_match_subsystem(enumerate, "hidraw");
-      udev_enumerate_scan_devices(enumerate);
-
-      struct udev_list_entry *devices = udev_enumerate_get_list_entry(enumerate);
-      struct udev_list_entry *dev_list_entry;
-      udev_list_entry_foreach(dev_list_entry, devices) {
-        const char *path = udev_list_entry_get_name(dev_list_entry);
-        struct udev_device *dev = udev_device_new_from_syspath(self->udev, path);
-        self->checkFoundDevice(dev);
-        udev_device_unref(dev);
-      }
-      udev_enumerate_unref(enumerate);
-
-      udev_monitor_enable_receiving(self->monitor) ;
-      int monfd = udev_monitor_get_fd(self->monitor) ;
-      while (true)
+      PointingList::iterator i = candidates.begin();
+      while (i != candidates.end())
       {
-        if (checkDev(monfd))
-          self->monitor_readable();
-      }
-      return 0 ;
-    }
-
-    void *linuxPointingDeviceManager::checkReports(void *context)
-    {
-      pthread_setcancelstate(PTHREAD_CANCEL_ENABLE, NULL) ;
-      pthread_setcanceltype(PTHREAD_CANCEL_DEFERRED, NULL) ;
-
-      PointingDeviceData *pdd = (PointingDeviceData *)context;
-      linuxPointingDeviceManager *self = (linuxPointingDeviceManager *)PointingDeviceManager::get();
-
-      while (true)
-      {
-        if (checkDev(pdd->devID))
-          self->hid_readable(pdd);
-      }
-      return 0 ;
-    }
-
-    linuxPointingDeviceManager::linuxPointingDeviceManager()
-    {
-      udev = udev_new();
-      if (!udev)
-        throw runtime_error("linuxPointingDeviceManager: udev_new failed");
-
-      monitor = udev_monitor_new_from_netlink(udev, "udev");
-      udev_monitor_filter_add_match_subsystem_devtype(monitor, "hidraw", NULL);
-
-      int ret = pthread_create(&thread, NULL, eventloop, (void*)this);
-      if (ret < 0)
-      {
-        perror("linuxPointingDeviceManager::linuxPointingDeviceManager") ;
-        throw runtime_error("linuxPointingDeviceManager: pthread_create failed") ;
-      }
-    }
-
-    void linuxPointingDeviceManager::monitor_readable(void)
-    {
-        struct udev_device *dev = udev_monitor_receive_device(monitor) ;
-        if (dev)
+        linuxPointingDevice *device = *i;
+        // Found matching device
+        // Move it from candidates to devMap
+        if (pdd->desc.devURI == device->uri)
         {
-          const char *action = udev_device_get_action(dev) ;
-          if (!strcmp(action,"add")) {
-            checkFoundDevice(dev) ;
-          } else if (!strcmp(action,"remove")) {
-            checkLostDevice(dev) ;
-          }
-          udev_device_unref(dev) ;
+          candidates.erase(i++);
+          processMatching(pdd, device);
         }
+        else
+          i++;
+      }
+    }
+  }
+
+  void linuxPointingDeviceManager::processMatching(PointingDeviceData *pdd, linuxPointingDevice *device)
+  {
+    pdd->pointingList.push_back(device);
+    device->active = true;
+    device->productID = pdd->desc.productID;
+    device->vendorID = pdd->desc.vendorID;
+    device->vendor = pdd->desc.vendor;
+    device->product = pdd->desc.product;
+    if (device->seize)
+      enableDevice(false, device->vendor + " " + device->product);
+  }
+
+  int linuxPointingDeviceManager::readHIDDescriptor(int devID, HIDReportParser *parser)
+  {
+    int descSize = 0;
+    int res = ioctl(devID, HIDIOCGRDESCSIZE, &descSize);
+    if (res < 0) {
+      std::cerr << "linuxPointingDeviceManager::checkFoundDevice: unable to open HID device" << std::endl ;
+      return 0;
+    }
+    if (debugLevel > 0)
+      std::cerr << "  descriptor size: " << descSize << std::endl ;
+    struct hidraw_report_descriptor descriptor ;
+    descriptor.size = descSize ;
+    res = ioctl(devID, HIDIOCGRDESC, &descriptor) ;
+    if (!parser->setDescriptor(descriptor.value, descSize))
+      std::cerr << "linuxPointingDeviceManager::readHIDDescriptor: unable to parse the HID report descriptor" << std::endl;
+    if (res < 0) {
+      perror("linuxPointingDeviceManager::checkFoundDevice") ;
+      return 0;
+    } else {
+      if (debugLevel > 1) {
+        std::cerr << "  descriptor (" << descriptor.size << " bytes): " ;
+        std::string reportstring ;
+        reportstring.assign((const char *)descriptor.value, descriptor.size) ;
+        std::cerr << Base64::encode(reportstring) << std::endl ;
+      }
+    }
+    return parser->getReportLength();
+  }
+
+  void linuxPointingDeviceManager::checkFoundDevice(struct udev_device *hiddev)
+  {
+    struct udev_device *usbdev = udev_device_get_parent_with_subsystem_devtype(hiddev, "usb", "usb_device") ;
+    if (!usbdev) return ;
+
+    const char *devnode = udev_device_get_devnode(hiddev);
+    int devID = open(devnode, O_RDONLY);
+    if (devID == -1) {
+      std::cerr << "linuxPointingDeviceManager::checkFoundDevice: unable to open HID device" << std::endl ;
+      return ;
+    }
+    PointingDeviceData *pdd = new PointingDeviceData;
+    devMap[devnode] = pdd;
+    pdd->devID = devID;
+    fillDescriptorInfo(hiddev, usbdev, pdd->desc);
+    addDevice(pdd->desc);
+    matchCandidates();
+
+    pdd->reportLength = readHIDDescriptor(devID, &pdd->parser);
+
+    if (debugLevel > 0)
+    {
+      bool match = pdd->pointingList.size();
+      std::cout << (match ? "+ " : "  ") << pdd->desc.devURI
+           << " [" << std::hex << "vend:0x" << pdd->desc.vendorID
+           << ", prod:0x" << pdd->desc.productID
+           << std::dec << " - " << pdd->desc.vendor
+           << " " << pdd->desc.product << "]" << std::endl;
     }
 
-    void linuxPointingDeviceManager::fillDescriptorInfo(struct udev_device *hiddev, struct udev_device *usbdev, PointingDeviceDescriptor &desc)
+    int ret = pthread_create(&pdd->thread, NULL, checkReports, pdd);
+    if (ret < 0)
     {
-      desc.devURI = uriFromDevice(hiddev);
-      desc.vendor = sysattr2string(usbdev, "product", "????");
-      desc.product = sysattr2string(usbdev, "manufacturer", "????");
-      desc.vendorID = sysattr2int(usbdev, "idVendor");
-      desc.productID = sysattr2int(usbdev, "idProduct");
+      perror("linuxPointingDeviceManager::checkFoundDevice") ;
+      throw runtime_error("linuxPointingDeviceManager: pthread_create failed") ;
     }
+  }
 
-    void linuxPointingDeviceManager::convertAnyCandidates()
+  void linuxPointingDeviceManager::checkLostDevice(struct udev_device *hiddev)
+  {
+    const char *devnode = udev_device_get_devnode(hiddev);
+    devMap_t::iterator it = devMap.find(devnode);
+    if (it != devMap.end())
     {
-      for (PointingList::iterator it = candidates.begin(); it != candidates.end(); it++)
+      PointingDeviceData *pdd = it->second;
+      if (pthread_cancel(pdd->thread) < 0)
+        perror("linuxPointingDeviceManager::checkLostDevice");
+      removeDevice(pdd->desc);
+      close(pdd->devID);
+      for (PointingList::iterator i = pdd->pointingList.begin(); i != pdd->pointingList.end(); i++)
+      {
+        linuxPointingDevice *device = *i;
+        if (device->seize)
+          enableDevice(true, device->vendor + " " + device->product);
+        device->active = false;
+        candidates.push_back(device);
+      }
+      delete pdd;
+      devMap.erase(it);
+    }
+    matchCandidates();
+  }
+
+  void linuxPointingDeviceManager::hid_readable(PointingDeviceData *pdd)
+  {
+    TimeStamp::inttime now = TimeStamp::createAsInt() ;
+    unsigned char *report = new unsigned char[pdd->reportLength];
+    int32_t length = read(pdd->devID, report, pdd->reportLength);
+    pdd->parser.setReport(report);
+    delete report;
+
+    if (length > 0)
+    {
+      int dx=0, dy=0, buttons=0;
+      pdd->parser.getReportData(&dx, &dy, &buttons);
+      for (PointingList::iterator it = pdd->pointingList.begin(); it != pdd->pointingList.end(); it++)
       {
         linuxPointingDevice *device = *it;
-        if (!device->anyURI.asString().empty())
-          device->uri = anyToSpecific(device->anyURI);
+        device->registerTimestamp(now);
+        if (device->callback)
+          device->callback(device->callback_context, now, dx, dy, buttons);
       }
     }
+  }
 
-    void linuxPointingDeviceManager::matchCandidates()
+  void linuxPointingDeviceManager::addPointingDevice(linuxPointingDevice *device)
+  {
+    debugLevel = MAX(debugLevel, device->debugLevel);
+    candidates.push_back(device);
+    matchCandidates();
+  }
+
+  void linuxPointingDeviceManager::removePointingDevice(linuxPointingDevice *device)
+  {
+    URI uri = device->uri;
+    for(devMap_t::iterator it = devMap.begin(); it != devMap.end(); it++)
     {
-      convertAnyCandidates();
-      for(devMap_t::iterator it = devMap.begin(); it != devMap.end(); it++)
+      PointingDeviceData *pdd = it->second;
+      if (pdd->desc.devURI == uri)
       {
-        PointingDeviceData *pdd = it->second;
-
-        PointingList::iterator i = candidates.begin();
-        while (i != candidates.end())
-        {
-          linuxPointingDevice *device = *i;
-          // Found matching device
-          // Move it from candidates to devMap
-          if (pdd->desc.devURI == device->uri)
-          {
-            candidates.erase(i++);
-            processMatching(pdd, device);
-          }
-          else
-            i++;
-        }
+        pdd->pointingList.remove(device);
+        break;
       }
     }
+    candidates.remove(device);
+  }
 
-    void linuxPointingDeviceManager::processMatching(PointingDeviceData *pdd, linuxPointingDevice *device)
-    {
-      pdd->pointingList.push_back(device);
-      device->active = true;
-      device->productID = pdd->desc.productID;
-      device->vendorID = pdd->desc.vendorID;
-      device->vendor = pdd->desc.vendor;
-      device->product = pdd->desc.product;
-      if (device->seize)
-        enableDevice(false, device->vendor + " " + device->product);
-    }
-
-    int linuxPointingDeviceManager::readHIDDescriptor(int devID, HIDReportParser *parser)
-    {
-      int descSize = 0;
-      int res = ioctl(devID, HIDIOCGRDESCSIZE, &descSize);
-      if (res < 0) {
-        std::cerr << "linuxPointingDeviceManager::checkFoundDevice: unable to open HID device" << std::endl ;
-        return 0;
-      }
-      if (debugLevel > 0)
-        std::cerr << "  descriptor size: " << descSize << std::endl ;
-      struct hidraw_report_descriptor descriptor ;
-      descriptor.size = descSize ;
-      res = ioctl(devID, HIDIOCGRDESC, &descriptor) ;
-      if (!parser->setDescriptor(descriptor.value, descSize))
-        std::cerr << "linuxPointingDeviceManager::readHIDDescriptor: unable to parse the HID report descriptor" << std::endl;
-      if (res < 0) {
-        perror("linuxPointingDeviceManager::checkFoundDevice") ;
-        return 0;
-      } else {
-        if (debugLevel > 1) {
-          std::cerr << "  descriptor (" << descriptor.size << " bytes): " ;
-          std::string reportstring ;
-          reportstring.assign((const char *)descriptor.value, descriptor.size) ;
-          std::cerr << Base64::encode(reportstring) << std::endl ;
-        }
-      }
-      return parser->getReportLength();
-    }
-
-    void linuxPointingDeviceManager::checkFoundDevice(struct udev_device *hiddev)
-    {
-      struct udev_device *usbdev = udev_device_get_parent_with_subsystem_devtype(hiddev, "usb", "usb_device") ;
-      if (!usbdev) return ;
-
-      const char *devnode = udev_device_get_devnode(hiddev);
-      int devID = open(devnode, O_RDONLY);
-      if (devID == -1) {
-        std::cerr << "linuxPointingDeviceManager::checkFoundDevice: unable to open HID device" << std::endl ;
-        return ;
-      }
-      PointingDeviceData *pdd = new PointingDeviceData;
-      devMap[devnode] = pdd;
-      pdd->devID = devID;
-      fillDescriptorInfo(hiddev, usbdev, pdd->desc);
-      addDevice(pdd->desc);
-      matchCandidates();
-
-      pdd->reportLength = readHIDDescriptor(devID, &pdd->parser);
-
-      if (debugLevel > 0)
-      {
-        bool match = pdd->pointingList.size();
-        std::cout << (match ? "+ " : "  ") << pdd->desc.devURI
-             << " [" << std::hex << "vend:0x" << pdd->desc.vendorID
-             << ", prod:0x" << pdd->desc.productID
-             << std::dec << " - " << pdd->desc.vendor
-             << " " << pdd->desc.product << "]" << std::endl;
-      }
-
-      int ret = pthread_create(&pdd->thread, NULL, checkReports, pdd);
-      if (ret < 0)
-      {
-        perror("linuxPointingDeviceManager::checkFoundDevice") ;
-        throw runtime_error("linuxPointingDeviceManager: pthread_create failed") ;
-      }
-    }
-
-    void linuxPointingDeviceManager::checkLostDevice(struct udev_device *hiddev)
-    {
-      const char *devnode = udev_device_get_devnode(hiddev);
-      devMap_t::iterator it = devMap.find(devnode);
-      if (it != devMap.end())
-      {
-        PointingDeviceData *pdd = it->second;
-        if (pthread_cancel(pdd->thread) < 0)
-          perror("linuxPointingDeviceManager::checkLostDevice");
-        removeDevice(pdd->desc);
-        close(pdd->devID);
-        for (PointingList::iterator i = pdd->pointingList.begin(); i != pdd->pointingList.end(); i++)
-        {
-          linuxPointingDevice *device = *i;
-          if (device->seize)
-            enableDevice(true, device->vendor + " " + device->product);
-          device->active = false;
-          candidates.push_back(device);
-        }
-        delete pdd;
-        devMap.erase(it);
-      }
-      matchCandidates();
-    }
-
-    void linuxPointingDeviceManager::hid_readable(PointingDeviceData *pdd)
-    {
-      TimeStamp::inttime now = TimeStamp::createAsInt() ;
-      unsigned char *report = new unsigned char[pdd->reportLength];
-      int32_t length = read(pdd->devID, report, pdd->reportLength);
-      pdd->parser.setReport(report);
-      delete report;
-
-      if (length > 0)
-      {
-        int dx=0, dy=0, buttons=0;
-        pdd->parser.getReportData(&dx, &dy, &buttons);
-        for (PointingList::iterator it = pdd->pointingList.begin(); it != pdd->pointingList.end(); it++)
-        {
-          linuxPointingDevice *device = *it;
-          device->registerTimestamp(now);
-          if (device->callback)
-            device->callback(device->callback_context, now, dx, dy, buttons);
-        }
-      }
-    }
-
-    void linuxPointingDeviceManager::addPointingDevice(linuxPointingDevice *device)
-    {
-      debugLevel = MAX(debugLevel, device->debugLevel);
-      candidates.push_back(device);
-      matchCandidates();
-    }
-
-    void linuxPointingDeviceManager::removePointingDevice(linuxPointingDevice *device)
-    {
-      URI uri = device->uri;
-      for(devMap_t::iterator it = devMap.begin(); it != devMap.end(); it++)
-      {
-        PointingDeviceData *pdd = it->second;
-        if (pdd->desc.devURI == uri)
-        {
-          pdd->pointingList.remove(device);
-          break;
-        }
-      }
-      candidates.remove(device);
-    }
-
-    linuxPointingDeviceManager::~linuxPointingDeviceManager()
-    {
-      if (pthread_cancel(thread) < 0)
-        perror("linuxPointingDeviceManager::~linuxPointingDeviceManager");
-      // TODO cancel all threads
-      udev_monitor_unref(monitor);
-      udev_unref(udev);
-    }
+  linuxPointingDeviceManager::~linuxPointingDeviceManager()
+  {
+    if (pthread_cancel(thread) < 0)
+      perror("linuxPointingDeviceManager::~linuxPointingDeviceManager");
+    // TODO cancel all threads
+    udev_monitor_unref(monitor);
+    udev_unref(udev);
+  }
 }

--- a/pointing/input/linux/linuxPointingDeviceManager.h
+++ b/pointing/input/linux/linuxPointingDeviceManager.h
@@ -47,6 +47,7 @@ namespace pointing {
       HIDReportParser parser;
       int devID;
       int reportLength;
+      pthread_t thread;
     };
 
     PointingList candidates;
@@ -65,7 +66,8 @@ namespace pointing {
      * @brief This static function works in another thread.
      * It queries for added or removed devices.
      */
-    static void *eventloop(void *self) ;
+    static void *eventloop(void *self);
+    static void *checkReports(void *self);
 
     void monitor_readable();
     void hid_readable(PointingDeviceData *pdd);

--- a/pointing/input/linux/linuxPointingDeviceManager.h
+++ b/pointing/input/linux/linuxPointingDeviceManager.h
@@ -69,6 +69,8 @@ namespace pointing {
     static void *eventloop(void *self);
     static void *checkReports(void *self);
 
+    void enableDevice(bool value, std::string fullName);
+
     void monitor_readable();
     void hid_readable(PointingDeviceData *pdd);
 

--- a/pointing/input/linux/linuxPointingDeviceManager.h
+++ b/pointing/input/linux/linuxPointingDeviceManager.h
@@ -17,41 +17,75 @@
 #define linuxPointingDeviceManager_h
 
 #include <pointing/input/PointingDeviceManager.h>
+#include <pointing/input/linux/linuxPointingDevice.h>
 #include <pthread.h>
 #include <libudev.h>
 #include <string>
 #include <map>
+#include <list>
+#include <pointing/utils/HIDReportParser.h>
+
+// TODO remove includes
 
 namespace pointing {
 
-    /**
-     * @brief The linuxPointingDeviceManager class is the platform-specific
-     * subclass of the PointingDeviceManager class
-     */
-    class linuxPointingDeviceManager : public PointingDeviceManager
+  /**
+   * @brief The linuxPointingDeviceManager class is the platform-specific
+   * subclass of the PointingDeviceManager class
+   */
+  class linuxPointingDeviceManager : public PointingDeviceManager
+  {
+    friend class PointingDeviceManager;
+    friend class linuxPointingDevice;
+
+    typedef std::list<linuxPointingDevice *> PointingList;
+
+    struct PointingDeviceData
     {
-        friend class PointingDeviceManager;
-        struct udev *udev ;
-        struct udev_monitor *monitor ;
-        
-        pthread_t thread ;
-        
-        /**
-         * @brief This static function works in another thread.
-         * It queries for added or removed devices.
-         */
-        static void *eventloop(void *self) ;
-       
-        void monitor_readable() ;
-        
-        void ConvertDevice(struct udev_device *hiddev, struct udev_device *usbdev, PointingDeviceDescriptor &desc);
-        
-        void checkFoundDevice(struct udev_device *device) ;
-        void checkLostDevice(struct udev_device *device) ;
-        
-        linuxPointingDeviceManager();
-        ~linuxPointingDeviceManager();
+      PointingDeviceDescriptor desc;
+      PointingList pointingList;
+      HIDReportParser parser;
+      int devID;
+      int reportLength;
     };
+
+    PointingList candidates;
+    int debugLevel;
+
+    typedef std::map<std::string, PointingDeviceData *> devMap_t;
+
+    devMap_t devMap;
+
+    struct udev *udev ;
+    struct udev_monitor *monitor ;
+
+    pthread_t thread ;
+
+    /**
+     * @brief This static function works in another thread.
+     * It queries for added or removed devices.
+     */
+    static void *eventloop(void *self) ;
+
+    void monitor_readable();
+    void hid_readable(PointingDeviceData *pdd);
+
+    int readHIDDescriptor(int devID, HIDReportParser *parser);
+    void fillDescriptorInfo(struct udev_device *hiddev, struct udev_device *usbdev, PointingDeviceDescriptor &desc);
+
+    void processMatching(PointingDeviceData *pdd, linuxPointingDevice *device);
+    void convertAnyCandidates();
+    void matchCandidates();
+
+    void checkFoundDevice(struct udev_device *device) ;
+    void checkLostDevice(struct udev_device *device) ;
+
+    void addPointingDevice(linuxPointingDevice *device);
+    void removePointingDevice(linuxPointingDevice *device);
+
+    linuxPointingDeviceManager();
+    ~linuxPointingDeviceManager();
+  };
 
 }
 

--- a/pointing/input/osx/osxPointingDevice.cpp
+++ b/pointing/input/osx/osxPointingDevice.cpp
@@ -69,6 +69,8 @@ namespace pointing {
       }
     }
 
+    if (expanded || seize)
+        URI::addQueryArg(result.query, "seize", seize);
     if (expanded || debugLevel)
         URI::addQueryArg(result.query, "debugLevel", debugLevel);
     if (expanded || forced_cpi > 0)

--- a/pointing/input/osx/osxPointingDeviceManager.cpp
+++ b/pointing/input/osx/osxPointingDeviceManager.cpp
@@ -173,7 +173,7 @@ namespace pointing {
 
   void osxPointingDeviceManager::removePointingDevice(osxPointingDevice *device)
   {
-    URI uri = device->getURI();
+    URI uri = device->uri;
     for(devMap_t::iterator it = devMap.begin(); it != devMap.end(); it++)
     {
       PointingDeviceData *pdd = it->second;

--- a/pointing/input/osx/osxPointingDeviceManager.cpp
+++ b/pointing/input/osx/osxPointingDeviceManager.cpp
@@ -27,8 +27,9 @@ namespace pointing {
 
   void fillDescriptorInfo(IOHIDDeviceRef devRef, PointingDeviceDescriptor &desc)
   {
-    desc.devURI = hidDeviceURI(devRef).asString();
-    desc.name = hidDeviceName(devRef);
+    desc.devURI = hidDeviceURI(devRef);
+    desc.vendor = hidDeviceGetStringProperty(devRef, CFSTR(kIOHIDManufacturerKey));
+    desc.product = hidDeviceGetStringProperty(devRef, CFSTR(kIOHIDProductKey));
     desc.vendorID = hidDeviceGetIntProperty(devRef, CFSTR(kIOHIDVendorIDKey));
     desc.productID = hidDeviceGetIntProperty(devRef, CFSTR(kIOHIDProductIDKey));
   }
@@ -63,7 +64,7 @@ namespace pointing {
         osxPointingDevice *device = *i;
         // Found matching device
         // Move it from candidates to devMap
-        if (pdd->desc.devURI == device->uri.asString())
+        if (pdd->desc.devURI == device->uri)
         {
           candidates.erase(i++);
           processMatching(pdd, device);
@@ -176,7 +177,7 @@ namespace pointing {
     for(devMap_t::iterator it = devMap.begin(); it != devMap.end(); it++)
     {
       PointingDeviceData *pdd = it->second;
-      if (pdd->desc.devURI == uri.asString())
+      if (pdd->desc.devURI == uri)
       {
         pdd->pointingList.remove(device);
         break;

--- a/pointing/input/windows/winPointingDevice.cpp
+++ b/pointing/input/windows/winPointingDevice.cpp
@@ -99,9 +99,10 @@ namespace pointing {
               URI::getQueryArg(desc.devURI.query, "handle", &curHandle);
               bool match = (handle == curHandle);
               std::cout << (match ? "+ " : "  ") << desc.devURI.asString()
-                   << " [" << std::hex << "vend:0x" << desc.vendorID
+                   << " [ " << std::hex << "vend:0x" << desc.vendorID
                    << ", prod:0x" << desc.productID
-                   << std::dec << " - " << desc.name << " ]" << std::endl;
+                   << std::dec << " - " << desc.vendor
+                   << " - " << desc.product << " ]" << std::endl;
           }
         }
 

--- a/pointing/input/windows/winPointingDevice.cpp
+++ b/pointing/input/windows/winPointingDevice.cpp
@@ -27,17 +27,6 @@ namespace pointing {
 #define WIN_DEFAULT_DEBUGLEVEL  0
 #define WIN_DEFAULT_HANDLE      0
 
-    URI uriForHandle(HANDLE h)
-    {
-        std::stringstream ss;
-        if (h)
-            ss << "winhid:?handle=0x" << std::hex
-               << std::noshowbase << PtrToUint(h);
-        else
-            ss << "any:";
-        return URI(ss.str());
-    }
-
     void winPointingDevice::setActive(HANDLE h, bool isActive)
     {
       if (h == (HANDLE)handle)
@@ -96,7 +85,7 @@ namespace pointing {
         if (this->uri.scheme != "any")
         {
           URI::getQueryArg(uri.query, "handle", &handle);
-          this->uri = uriForHandle((HANDLE)handle);
+          this->uri = winPointingDeviceManager::uriForHandle((HANDLE)handle);
         }
 
         man->dispatcher->addPointingDevice((HANDLE)handle, this);
@@ -107,9 +96,9 @@ namespace pointing {
           {
               PointingDeviceDescriptor desc = *it;
               unsigned curHandle = 0;
-              URI::getQueryArg(URI(desc.devURI).query, "handle", &curHandle);
+              URI::getQueryArg(desc.devURI.query, "handle", &curHandle);
               bool match = (handle == curHandle);
-              std::cout << (match ? "+ " : "  ") << desc.devURI
+              std::cout << (match ? "+ " : "  ") << desc.devURI.asString()
                    << " [" << std::hex << "vend:0x" << desc.vendorID
                    << ", prod:0x" << desc.productID
                    << std::dec << " - " << desc.name << " ]" << std::endl;

--- a/pointing/input/windows/winPointingDeviceManager.cpp
+++ b/pointing/input/windows/winPointingDeviceManager.cpp
@@ -21,12 +21,15 @@ using namespace std;
 
 namespace pointing
 {
-    string uriStringFromHandle(HANDLE h)
+    URI uriForHandle(HANDLE h)
     {
-        stringstream uriStream;
-        uriStream << "winhid:?handle=0x" 
-                  << hex << noshowbase << PtrToUint(h);
-        return uriStream.str();
+        std::stringstream ss;
+        if (h)
+            ss << "winhid:?handle=0x" << std::hex
+               << std::noshowbase << PtrToUint(h);
+        else
+            ss << "any:";
+        return URI(ss.str());
     }
 
     bool winPointingDeviceManager::ConvertDevice(HANDLE h, PointingDeviceDescriptor &desc)
@@ -39,7 +42,7 @@ namespace pointing
         if (productID != -1)
             desc.productID = productID;
         desc.name = vendor + " - " + product;
-        desc.devURI = uriStringFromHandle(h);
+        desc.devURI = uriForHandle(h);
         return result;
     }
 

--- a/pointing/input/windows/winPointingDeviceManager.cpp
+++ b/pointing/input/windows/winPointingDeviceManager.cpp
@@ -21,7 +21,7 @@ using namespace std;
 
 namespace pointing
 {
-    URI uriForHandle(HANDLE h)
+    URI winPointingDeviceManager::uriForHandle(HANDLE h)
     {
         std::stringstream ss;
         if (h)
@@ -41,14 +41,16 @@ namespace pointing
             desc.vendorID = vendorID;
         if (productID != -1)
             desc.productID = productID;
-        desc.name = vendor + " - " + product;
+        desc.vendor = vendor;
+        desc.product = product;
         desc.devURI = uriForHandle(h);
         return result;
     }
 
     void winPointingDeviceManager::unregisterMouseDevice(HANDLE h)
     {
-        PointingDeviceDescriptor desc(uriStringFromHandle(h));
+        PointingDeviceDescriptor desc;
+        desc.devURI = uriForHandle(h);
         removeDevice(desc);
     }
 

--- a/pointing/input/windows/winPointingDeviceManager.h
+++ b/pointing/input/windows/winPointingDeviceManager.h
@@ -29,6 +29,8 @@ namespace pointing
         void registerMouseDevice(HANDLE);
         void unregisterMouseDevice(HANDLE h);
 
+        static URI uriForHandle(HANDLE h);
+
         winHIDDeviceDispatcher *dispatcher;
 
         friend class PointingDeviceManager;

--- a/pointing/pointing.pro
+++ b/pointing/pointing.pro
@@ -94,12 +94,12 @@ macx {
 }
 
 unix:!macx {
-  HEADERS += $$HERE/input/linux/linuxHIDPointingDevice.h \
+  HEADERS += $$HERE/input/linux/linuxPointingDevice.h \
              $$HERE/output/linux/xorgDisplayDevice.h \
              $$HERE/transferfunctions/linux/xorgSystemPointerAcceleration.h \
              $$HERE/input/linux/linuxPointingDeviceManager.h \
              $$HERE/output/linux/xorgDisplayDeviceManager.h
-  SOURCES += $$HERE/input/linux/linuxHIDPointingDevice.cpp \
+  SOURCES += $$HERE/input/linux/linuxPointingDevice.cpp \
              $$HERE/output/linux/xorgDisplayDevice.cpp \
              $$HERE/transferfunctions/linux/xorgSystemPointerAcceleration.cpp \
              $$HERE/input/linux/linuxPointingDeviceManager.cpp \

--- a/pointing/utils/URI.cpp
+++ b/pointing/utils/URI.cpp
@@ -100,6 +100,11 @@ namespace pointing {
     return !(*this == other);
   }
 
+  std::ostream &
+  operator<<(std::ostream &os, URI const &uri) {
+    return os << uri.asString();
+  }
+
   bool
   URI::resemble(const URI &other) const {
     if (scheme!=other.scheme) return false ;

--- a/pointing/utils/URI.h
+++ b/pointing/utils/URI.h
@@ -144,6 +144,8 @@ namespace pointing {
     void debug(std::ostream& out) const ;
 
   } ;
+
+  std::ostream &operator<<(std::ostream &os, URI const &uri) ;
   
 }
 

--- a/tests/pointingdevice/pointingdevice.h
+++ b/tests/pointingdevice/pointingdevice.h
@@ -59,13 +59,23 @@ private slots:
       QCOMPARE(productID, 2);
       delete input;
     }
-
+		
     void isNotActive()
     {
       std::string uri = "any:?vendor=1&product=2";
       PointingDevice *input = PointingDevice::create(uri);
       QCOMPARE(input->isActive(), false);
       delete input;
+    }
+
+    void multipleAny()
+    {
+      PointingDevice *input = PointingDevice::create("any:");
+      PointingDevice *input2 = PointingDevice::create("any:");
+      PointingDevice *input3 = PointingDevice::create("any:");
+      delete input3;
+      delete input;
+      delete input2;
     }
 };
 

--- a/tests/tests.pro
+++ b/tests/tests.pro
@@ -6,10 +6,4 @@
 
 TEMPLATE = subdirs
 
-SUBDIRS += interpolation subpixel hidreportparser
-
-# FIXME tests are not passing on linux
-# Need to change linuxHIDPointingDevice
-macx:windows {
-  SUBDIRS += pointingdevice
-}
+SUBDIRS += interpolation subpixel hidreportparser pointingdevice


### PR DESCRIPTION
# The list of changes
- Added `linuxPointingDevice` instead of `linuxHIDPointingDevice`.
- Moved all threading and hardware access to `linuxPointingDeviceManager`.
- Minor changes and fixes

This change was necessary, because there was a crash on Linux while creating more than one `PointingDevice` with the same URI. It was due to accessing a single file descriptor from different pointing devices (with different threads).

With this change, a single device file descriptor accessed only by a single thread created in `linuxPointingDeviceManager`. And `linuxPointingDeviceManager` deals with multiple `linuxPointingDevice` objects.
