### PR TITLE
Parser improvements

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -56,6 +56,7 @@ tests/interpolation/interpolation
 tests/subpixel/subpixel
 tests/hidreportparser/hidreportparser
 tests/pointingdevice/pointingdevice
+tests/frequencyestimator/frequencyestimator
 tests/*/target_wrapper.sh
 bindings/Node/cache
 bindings/Node/nw

--- a/.travis.yml
+++ b/.travis.yml
@@ -48,6 +48,7 @@ install:
           sudo apt-get install -qq freeglut3-dev ;
       elif [ $TRAVIS_OS_NAME == osx ] ; then
           brew ls | grep -wq qt || brew install qt ;
+          brew link qt5 --force ;
       fi
     - git config --global user.email "libpointing@inria.fr"
     - git config --global user.name "Travis CI"

--- a/pointing/input/PointingDeviceManager.h
+++ b/pointing/input/PointingDeviceManager.h
@@ -97,6 +97,7 @@ namespace pointing
         {
           PointingDeviceDescriptor desc;
           PointingList pointingList;
+          virtual ~PointingDeviceData() {}
         };
 
         std::map<identifier, PointingDeviceData *> devMap;

--- a/pointing/input/osx/osxPointingDeviceManager.cpp
+++ b/pointing/input/osx/osxPointingDeviceManager.cpp
@@ -97,7 +97,8 @@ namespace pointing {
     if (!manager)
       throw std::runtime_error("IOHIDManagerCreate failed");
 
-    const char *plist = hidDeviceFromVendorProductUsagePageUsage(0, 0, kHIDPage_GenericDesktop, kHIDUsage_GD_Mouse).c_str();
+    std::string xml = hidDeviceFromVendorProductUsagePageUsage(0, 0, kHIDPage_GenericDesktop, kHIDUsage_GD_Mouse);
+    const char *plist = xml.c_str();
     CFMutableDictionaryRef device_match = (CFMutableDictionaryRef)getPropertyListFromXML(plist);
     IOHIDManagerSetDeviceMatching(manager, device_match);
 

--- a/pointing/input/osx/osxPointingDeviceManager.h
+++ b/pointing/input/osx/osxPointingDeviceManager.h
@@ -20,14 +20,13 @@
 #include <list>
 #include <pointing/input/PointingDeviceManager.h>
 #include <IOKit/hid/IOHIDManager.h>
-#include <pointing/input/osx/osxPointingDevice.h>
 #include <pointing/utils/HIDReportParser.h>
 
 #include <iomanip>
 
 namespace pointing
 {
-/**
+  /**
    * @brief The osxPointingDeviceManager class is the platform-specific
    * subclass of the PointingDeviceManager class.
    *
@@ -44,7 +43,8 @@ namespace pointing
     {
       HIDReportParser parser;
       uint8_t report[64];
-      IOHIDDeviceRef devRef;
+      IOHIDDeviceRef devRef = nullptr;
+      virtual ~osxPointingDeviceData();
     };
 
     void processMatching(PointingDeviceData *pdd, SystemPointingDevice *device);

--- a/pointing/utils/HIDReportParser.cpp
+++ b/pointing/utils/HIDReportParser.cpp
@@ -165,7 +165,7 @@ namespace pointing
     }
   }
 
-  void HIDReportParser::clearAll()
+  void HIDReportParser::clearDescriptor()
   {
     lastUsage = 0;
     parentUsage = 0;
@@ -177,6 +177,8 @@ namespace pointing
     curRepInfo = &reportMap[0];
     dataMap.clear();
     usageList.clear();
+    delete[] report;
+    report = nullptr;
   }
 
   bool HIDReportParser::findCorrectReport()
@@ -217,7 +219,7 @@ namespace pointing
 
   bool HIDReportParser::setDescriptor(const unsigned char *desc, int size)
   {
-    clearAll();
+    clearDescriptor();
 
     int currentPosition = 0;
     while(currentPosition < size) {
@@ -227,7 +229,6 @@ namespace pointing
     }
     bool result = findCorrectReport();
 
-    delete[] report;
     int reportLength = getReportLength();
     if (!reportLength)
       return false; // Should not be zero

--- a/pointing/utils/HIDReportParser.cpp
+++ b/pointing/utils/HIDReportParser.cpp
@@ -27,11 +27,37 @@ namespace pointing
   HIDReportParser::HIDReportParser()
     :lastRepCount(0),lastRepSize(0),curRepInfo(0),report(0),debugLevel(0) { }
 
-  HIDReportParser::HIDReportParser(unsigned char *desc, int size, int debugLevel):
-    lastRepCount(0),lastRepSize(0),curRepInfo(0),report(0),debugLevel(debugLevel)
+  HIDReportParser::HIDReportParser(unsigned char *desc, int size, int debugLevel)
+    :lastRepCount(0),lastRepSize(0),curRepInfo(0),report(0),debugLevel(debugLevel)
   {
     if (size)
       setDescriptor(desc, size);
+  }
+
+  HIDReportParser::HIDReportParser(const HIDReportParser &other)
+    :HIDReportParser()
+  {
+    // Copy the MouseReport from the other's map
+    // And point to it.
+    reportMap[0] = *(other.curRepInfo);
+    curRepInfo = &reportMap[0];
+    // Create the container for the reports
+    report = new unsigned char[other.getReportLength()];
+  }
+
+  // Copy assignment
+  HIDReportParser& HIDReportParser::operator=(const HIDReportParser &other)
+  {
+    if (&other == this)
+      return *this;
+    // Copy the MouseReport from the other's map
+    // And point to it.
+    reportMap[0] = *(other.curRepInfo);
+    curRepInfo = &reportMap[0];
+    delete[] report;
+    // Create the container for the reports
+    report = new unsigned char[other.getReportLength()];
+    return *this;
   }
 
   void HIDReportParser::parseItem(const HIDItem &item)
@@ -186,7 +212,7 @@ namespace pointing
 
   HIDReportParser::~HIDReportParser()
   {
-    delete report;
+    delete[] report;
   }
 
   bool HIDReportParser::setDescriptor(const unsigned char *desc, int size)
@@ -201,9 +227,13 @@ namespace pointing
     }
     bool result = findCorrectReport();
 
-    delete report;
-    report = new unsigned char[curRepInfo->size];
-    memset(report, 0, curRepInfo->size / 8);
+    delete[] report;
+    int reportLength = getReportLength();
+    if (!reportLength)
+      return false; // Should not be zero
+
+    report = new unsigned char[reportLength];
+    memset(report, 0, reportLength);
     return result;
   }
 
@@ -215,7 +245,7 @@ namespace pointing
     return true;
   }
 
-  int HIDReportParser::getReportLength()
+  int HIDReportParser::getReportLength() const
   {
     // Should be divisible by 8, thus not returning ceil(curRepInfo->size / 8)
     return curRepInfo->size / 8;

--- a/pointing/utils/HIDReportParser.h
+++ b/pointing/utils/HIDReportParser.h
@@ -64,13 +64,13 @@ namespace pointing
     // Find the report which contains relative X and Y
     bool findCorrectReport();
 
-    // TODO Implement copy constructor which copies
-    // report and curRepInfo correctly
-    HIDReportParser(HIDReportParser const&);
-
   public:
     HIDReportParser();
     HIDReportParser(unsigned char *desc, int size, int debugLevel=0);
+
+    HIDReportParser(const HIDReportParser &);
+    HIDReportParser& operator=(const HIDReportParser &);
+
     ~HIDReportParser();
 
     /**
@@ -92,7 +92,7 @@ namespace pointing
      * @brief getReportLength
      * @return The length of the Mouse Report in bytes deduced from the report descriptor
      */
-    int getReportLength();
+    int getReportLength() const;
 
     /**
      * @brief getDxDy Gives the relative X and Y in mouse points

--- a/pointing/utils/HIDReportParser.h
+++ b/pointing/utils/HIDReportParser.h
@@ -59,7 +59,6 @@ namespace pointing
     int debugLevel;
 
     void parseItem(const HIDItem &item);
-    void clearAll();
 
     // Find the report which contains relative X and Y
     bool findCorrectReport();
@@ -72,6 +71,11 @@ namespace pointing
     HIDReportParser& operator=(const HIDReportParser &);
 
     ~HIDReportParser();
+
+    /**
+     * @brief Clears all data, so the parser can't parse anymore
+     */
+    void clearDescriptor();
 
     /**
      * @brief setDescriptor Sets the HID descriptor, parses it.


### PR DESCRIPTION
Hi @nroussel and @casiez,

Recently I cloned libpointing, and found out that on my machine (MacBook Pro 13 with OS X 10.11.6) consoleExample isn't working well. When i launch it, I have a list of 5 identical URIs:
`osxhid:/SPI/1000000/AppleHSSPIHIDDriver`
with different HID descriptors. However, only one descriptor is the good one. So, when i start consoleExample, there is 20 % chance that it works. So in the last commit, I modified the code a bit so that we consider an HID device as a pointing device only if the `HIDReportParser` was able to parse correctly the descriptor, which should be ok assuming that the parser works well.

I haven't pushed directly to master, I left this for you. Please review the last commit. And tell me if you agree.
With those changes, now I have only one `osxhid:/SPI/1000000/AppleHSSPIHIDDriver` with the correctly associated descriptor. All others are ignored.

Also, I added some more tests for the parser.