### PR TITLE
Fix setup.py, add missing libraries for windows

### DIFF
--- a/bindings/Python/cython/setup.py
+++ b/bindings/Python/cython/setup.py
@@ -3,46 +3,57 @@ from distutils.extension import Extension
 from Cython.Distutils import build_ext
 import platform
 
-libpointing='../../../'
+libpointing = '../../../'
 
-if platform.system() == 'Darwin':
+system = platform.system()
+
+if system == 'Darwin':
     ext_modules = [Extension(
-                        "pylibpointing", 
+                        "pylibpointing",
                         ["pylibpointing.pyx"],
-                        language="c++",   
+                        language="c++",
                         libraries=['pointing'],
                         include_dirs=[libpointing],
                         library_dirs=["./",libpointing+"pointing"],
                         extra_compile_args=["-stdlib=libc++", "-mmacosx-version-min=10.7", "-std=c++11"],
                         extra_link_args=["-mmacosx-version-min=10.7", "-framework", "CoreGraphics"],
                         )]
-elif platform.system() == 'Linux':
+elif system == 'Linux':
     ext_modules = [Extension(
-                         "pylibpointing", 
+                         "pylibpointing",
                          ["pylibpointing.pyx"],
-                         language="c++",   
+                         language="c++",
                          libraries=['pointing', "stdc++", "udev", "X11", "Xrandr"],
                          include_dirs=[
                             libpointing
                             ],
                          library_dirs=["./"]
-                         )    
-                         ]
+                         )]
+elif system == 'Windows':
+    ext_modules = [Extension(
+                         "pylibpointing",
+                         ["pylibpointing.pyx"],
+                         language="c++",
+                         libraries=['pointing', "user32", "advapi32", "setupapi", "hid"],
+                         include_dirs=[
+                            libpointing
+                            ],
+                         library_dirs=["./"]
+                         )]
 else:
     ext_modules = [Extension(
-                         "pylibpointing", 
+                         "pylibpointing",
                          ["pylibpointing.pyx"],
-                         language="c++",   
+                         language="c++",
                          libraries=['pointing', "stdc++"],
                          include_dirs=[
                             libpointing
                             ],
                          library_dirs=["./"]
-                         )    
-                         ]
+                         )]
 
 setup(
-  name = 'pylibpointing',
-  cmdclass = {'build_ext': build_ext},
-  ext_modules = ext_modules
+  name='pylibpointing',
+  cmdclass={'build_ext': build_ext},
+  ext_modules=ext_modules
 )


### PR DESCRIPTION
Added support for Building Python bindings on Windows.

Built using MSVC, Microsoft Visual Studio 2015
Built under:
Windows Kit 10.0.10586
Python 3.6
Cython 0.25.2