### PR TITLE
Nodejs binding: Pass the raw input data to the callback

### DIFF
--- a/bindings/Node/client/pointing.js
+++ b/bindings/Node/client/pointing.js
@@ -104,10 +104,10 @@ var pointing = new function() {
 		this.objects = {};
 		var that = this;
 
-		socket.on('pointingCallback', function(anId, timestamp, dx, dy, buttons) {
+		socket.on('pointingCallback', function(anId, timestamp, dx, dy, buttons, rawDx, rawDy) {
 			var input = that.objects[anId];
 			if(input && input.callback)
-				input.callback(timestamp, dx, dy, buttons);
+				input.callback(timestamp, dx, dy, buttons, rawDx, rawDy);
 		});
 
 		socket.on('pointingObjectInfo', function(anId, objInfo) {

--- a/bindings/Node/server/server.js
+++ b/bindings/Node/server/server.js
@@ -125,12 +125,12 @@ io.on('connection', function(socket) {
         else {
           result = func.applyi(dx, dy, timestamp);
         }
-        socket.emit('pointingCallback', id, timestamp, result.dx, result.dy, buttons);
+        socket.emit('pointingCallback', id, timestamp, result.dx, result.dy, buttons, dx, dy);
       });
     }
     else {
       input.setPointingCallback(function(timestamp, dx, dy, buttons) {
-        socket.emit('pointingCallback', id, timestamp, dx, dy, buttons);
+        socket.emit('pointingCallback', id, timestamp, dx, dy, buttons, dx, dy);
       });
     }
   });


### PR DESCRIPTION
In the nodejs binding, if we apply a TF to a pointing device, we have no way of retrieving the raw input data (TF is applied to the dx and dy parameters of the callback). This PR add raw input as optional arguments of the callback.

Because of the way arguments are handled by JS, this doesn't break compatibility with existing code (optional arguments do not need to be specified when defining the callback).
