### PR TITLE
X11: Handle multiple monitors + correct physical size and bounds for displays

### DIFF
--- a/pointing/output/DisplayDeviceManager.cpp
+++ b/pointing/output/DisplayDeviceManager.cpp
@@ -54,9 +54,9 @@ namespace pointing {
         #ifdef _WIN32
             singleManager = new winDisplayDeviceManager();
         #endif
-
+            
         #ifdef __linux__
-            singleManager = new DisplayDeviceManager();
+            singleManager = new xorgDisplayDeviceManager();
         #endif
         }
         return singleManager;
@@ -75,8 +75,9 @@ namespace pointing {
     {
         std::pair<std::set<DisplayDeviceDescriptor>::iterator,bool> ret;
         ret = descriptors.insert(descriptor);
-        if (ret.second) // If this device was not already there
+        if (ret.second) { // If this device was not already there
             callCallbackFunctions(descriptor, true);
+        }
     }
 
     void DisplayDeviceManager::removeDevice(DisplayDeviceDescriptor &descriptor)

--- a/pointing/output/linux/xorgDisplayDevice.cpp
+++ b/pointing/output/linux/xorgDisplayDevice.cpp
@@ -23,73 +23,163 @@
 
 namespace pointing {
 
-  xorgDisplayDevice::xorgDisplayDevice(void) {
-    dpy = XOpenDisplay(0) ;
-    if (dpy == NULL)
-      throw std::runtime_error("xorgDisplayDevice: can't open display") ;
-    cached = NOTHING ;
-  }
+xorgDisplayDevice::xorgDisplayDevice(void) {
+    displayID = -1;
+    initialize();
+}
 
-  xorgDisplayDevice::xorgDisplayDevice(URI uri) {
-    // uri.debug(std::cerr) ;
+xorgDisplayDevice::xorgDisplayDevice(URI uri) {
+    displayID = -1;
+    
+    if (!uri.path.empty()) {
+        std::istringstream to_int ;
+        to_int.str(uri.path.erase(0,1)) ; // Skip the leading '/'
+        to_int >> displayID ;
+    }
+    
+    initialize();
+}
 
-    if (uri.opaque.empty())
-      dpy = XOpenDisplay(0) ;
-    else
-      // hostname:displaynumber.screennumber
-      dpy = XOpenDisplay(uri.opaque.c_str()) ;
-    if (dpy == NULL)
-      throw std::runtime_error("xorgDisplayDevice: can't open display") ;
-    cached = NOTHING ;
-  }
+XRRModeInfo* xorgDisplayDevice::get_mode_info(RRMode mode) {
+    for (int m = 0; m < res->nmode; ++m) {
+        XRRModeInfo *mode_info = &res->modes[m];
+        
+        if (mode_info->id == mode) {
+            return mode_info;
+        }
+    }
+    
+    return NULL;
+}
 
-  DisplayDevice::Bounds
-  xorgDisplayDevice::getBounds(Bounds */*defval*/) {
+bool xorgDisplayDevice::get_bounds(int* width, int* height, int* x, int* y) {
+    // Need to get the crtc info
+    RRCrtc crtc = output_info->crtc;
+    XRRCrtcInfo* crtc_info = XRRGetCrtcInfo(dpy, res, crtc);
+    if (crtc_info != NULL) {
+        *width = crtc_info->width;
+        *height = crtc_info->height;
+        *x = crtc_info->x;
+        *y = crtc_info->y;
+        return true;
+    } else {
+        // This should not happen; but if it does, we just assume that the device use the preferred mode
+        RRMode mode_id = output_info->modes[output_info->npreferred];
+        XRRModeInfo* mode_info = get_mode_info(mode_id);
+        
+        if (mode_info != NULL) {
+            *width = mode_info->width;
+            *height = mode_info->height;
+            return true;
+        }
+    }
+    
+    XRRFreeCrtcInfo(crtc_info);
+    
+    return false;
+}
+
+void xorgDisplayDevice::initialize() {
+    dpy = XOpenDisplay(0);
+    
+    if (dpy == NULL) {
+        throw std::runtime_error("xorgDisplayDevice: can't open display");
+    }
+    
+    screen = DefaultScreen(dpy);
+    root = RootWindow(dpy, screen);
+    
+    res = XRRGetScreenResources(dpy, root);
+    
+    if (res == NULL) {
+        throw std::runtime_error("xorgDisplayDevice: can't retrieve screen resources") ;
+    }
+    
+    if (displayID == -1) {
+        // This happen when asking for "any" display
+        displayID = get_any_display_id();
+    }
+    
+    if (res->noutput <= displayID) {
+        throw std::runtime_error("xorgDisplayDevice: invalid display ID") ;
+    }
+    
+    output_info = XRRGetOutputInfo(dpy, res, res->outputs[displayID]);
+    
+    if (output_info == NULL) {
+        throw std::runtime_error("xorgDisplayDevice: can't retrieve output info") ;
+    }
+    cached = NOTHING;
+}
+
+
+int xorgDisplayDevice::get_any_display_id() {
+     for (int o = 0; o < res->noutput; o++) {
+         XRROutputInfo *output_info = XRRGetOutputInfo(dpy, res, res->outputs[o]);
+         bool connected = output_info->connection == RR_Connected;
+         XRRFreeOutputInfo(output_info);
+         
+         // Any display but among the connected ones
+         if (connected) {
+             return o;
+         }
+     }
+     
+     return -1;
+}
+
+DisplayDevice::Bounds
+xorgDisplayDevice::getBounds(Bounds */*defval*/) {
     if (cached & BOUNDS) return cached_bounds ;
-
-    int scr = DefaultScreen(dpy) ;
-    cached_bounds = DisplayDevice::Bounds(0, 0,
-					  DisplayWidth(dpy, scr),
-					  DisplayHeight(dpy, scr)) ;
+    
+    int width = 0;
+    int height = 0;
+    int x = 0;
+    int y = 0;
+    
+    get_bounds(&width, &height, &x, &y);
+    cached_bounds = DisplayDevice::Bounds(x, y, width, height);
+    
     cached = cached | BOUNDS ;
-
+    
     return cached_bounds ;
-  }
+}
 
-  DisplayDevice::Size
-  xorgDisplayDevice::getSize(Size */*defval*/) {
+DisplayDevice::Size
+xorgDisplayDevice::getSize(Size */*defval*/) {
     if (cached & SIZE) return cached_size ;
-
-    int scr = DefaultScreen(dpy) ;
-    cached_size = DisplayDevice::Size(DisplayWidthMM(dpy, scr),
-				      DisplayHeightMM(dpy, scr)) ;
+    
+    cached_size = DisplayDevice::Size(output_info->mm_width, output_info->mm_height) ;
     cached = cached | SIZE ;
-
+    
     return cached_size ;
-  }
+}
 
-  double
-  xorgDisplayDevice::getRefreshRate(double */*defval*/) {
+double
+xorgDisplayDevice::getRefreshRate(double */*defval*/) {
     if (cached & REFRESHRATE) return cached_refreshrate ;
-
-    Window root = RootWindow(dpy, DefaultScreen(dpy)) ;
+    
     XRRScreenConfiguration *sc = XRRGetScreenInfo(dpy, root) ;
     cached_refreshrate = XRRConfigCurrentRate(sc) ;
     cached = cached | REFRESHRATE ;
-  
+    
     return cached_refreshrate ;
-  }
+}
 
-  URI
-  xorgDisplayDevice::getURI(bool /*expanded*/) const {
+URI
+xorgDisplayDevice::getURI(bool /*expanded*/) const {
     URI uri ;
     uri.scheme = "xorgdisplay" ;
-    uri.opaque = DisplayString(dpy) ;
+    std::stringstream path ;
+    path << "/" << displayID ;
+    uri.path = path.str() ;
     return uri ;
-  }
+}
 
-  xorgDisplayDevice::~xorgDisplayDevice(void) {
-    XCloseDisplay(dpy) ;
-  }
+xorgDisplayDevice::~xorgDisplayDevice(void) {
+    XRRFreeScreenResources(res);
+    XRRFreeOutputInfo(output_info);
+    XCloseDisplay(dpy);
+}
 
 }

--- a/pointing/output/linux/xorgDisplayDevice.h
+++ b/pointing/output/linux/xorgDisplayDevice.h
@@ -18,6 +18,7 @@
 
 #include <pointing/output/DisplayDevice.h>
 
+#include <X11/extensions/Xrandr.h>
 #include <X11/Xlib.h>
 
 namespace pointing {
@@ -25,12 +26,23 @@ namespace pointing {
   class xorgDisplayDevice : public DisplayDevice {
 
     Display *dpy ;
+    int screen;
+    Window root;
+    XRRScreenResources *res;
+    XRROutputInfo* output_info;
+    
+    int displayID;
 
     typedef enum {NOTHING=0, BOUNDS=1, SIZE=2, REFRESHRATE=4} cachedinfo ;
     int cached ;
     DisplayDevice::Bounds cached_bounds ;
     DisplayDevice::Size cached_size ;
     double cached_refreshrate ;
+    
+    XRRModeInfo* get_mode_info(RRMode mode);
+    bool get_bounds(int* width, int* height, int* x, int* y);
+    int get_any_display_id();
+    void initialize();
 
   public:
   

--- a/pointing/output/linux/xorgDisplayDeviceManager.cpp
+++ b/pointing/output/linux/xorgDisplayDeviceManager.cpp
@@ -140,12 +140,11 @@ xorgDisplayDeviceManager::xorgDisplayDeviceManager() {
     
     XRRFreeScreenResources(res);
     
-    
-    int ret = pthread_create(&thread, NULL, eventloop, (void *)this);
+    /*int ret = pthread_create(&thread, NULL, eventloop, (void *)this);
     if (ret < 0)
     {
         perror("xorgDisplayDeviceManager::xorgDisplayDeviceManager");
         throw std::runtime_error("xorgDisplayDeviceManager: pthread_create failed");
-    }
+    }*/
 }
 }


### PR DESCRIPTION
This PR rewrite most of the code from xorgDisplayDevice using the XRandr API in order to support multiple monitors.

This should also fix incorrect physical size that were retrieved with some monitors.

Note: This does not fix the callback for display devices on Linux. There was incomplete and dead code (not called) in the source code of "xorgDisplayDeviceManager". I looked into it but it seems that the RROutputChangeNotifyMask does not work anymore. I did not find any other easy solution that did not involve polling. So I just left the code and prevented the thread from being created.