### PR TITLE
X11: Invert the Y axis

### DIFF
--- a/pointing/input/linux/linuxPointingDeviceManager.cpp
+++ b/pointing/input/linux/linuxPointingDeviceManager.cpp
@@ -398,7 +398,7 @@ namespace pointing {
         unsigned char *ptr = (unsigned char*)&ie;
         pdd->buttons = ptr[0] & 7; // 3 bits only
         dx = (char)ptr[1];
-        dy = (char)ptr[2];
+        dy = -(char)ptr[2];
       }
       hasRead++;
     }


### PR DESCRIPTION
It seems that on recent distribution of linux (at least, after Ubuntu 16.4), the Y axis is inverted when read from mouse file descriptor.

This PR simply invert the dy. 
This issue is strange, and I think more investigation should be done. This may not be the proper solution as my cursor is slightly off compared to the system one when I use libpointing's Xorg TF. But may be that the Xorg TF was updated.