### PR TITLE
pointingserver : class properties are now enumerables

### DIFF
--- a/bindings/Node/libpointing/pointing/ndisplaydevice.cc
+++ b/bindings/Node/libpointing/pointing/ndisplaydevice.cc
@@ -34,14 +34,7 @@ NDisplayDevice::~NDisplayDevice()
 Napi::Object NDisplayDevice::Init(Napi::Env env, Napi::Object exports) {
   Napi::HandleScope scope(env);
 
-  Napi::Function func = DefineClass(env, "DisplayDevice", {
-    InstanceAccessor("size", &NDisplayDevice::getSize, NULL),
-    InstanceAccessor("bounds", &NDisplayDevice::getBounds, NULL),
-    InstanceAccessor("resolution", &NDisplayDevice::getResolution, NULL),
-    InstanceAccessor("refreshRate", &NDisplayDevice::getRefreshRate, NULL),
-    InstanceAccessor("uri", &NDisplayDevice::getURI, NULL),
-     //NULL = no setter on a read-only property.
-  });
+  Napi::Function func = DefineClass(env, "DisplayDevice", {});
 
   constructor = Napi::Persistent(func);
   constructor.SuppressDestruct();
@@ -63,6 +56,12 @@ NDisplayDevice::NDisplayDevice(const Napi::CallbackInfo& info) : Napi::ObjectWra
   }
   std::string uri = info[0].ToString().Utf8Value();
   this->output = DisplayDevice::create(uri);
+
+  addProperty<NDisplayDevice>(info, "size", &NDisplayDevice::getSize);
+  addProperty<NDisplayDevice>(info, "bounds", &NDisplayDevice::getBounds);
+  addProperty<NDisplayDevice>(info, "resolution", &NDisplayDevice::getResolution);
+  addProperty<NDisplayDevice>(info, "refreshRate", &NDisplayDevice::getRefreshRate);
+  addProperty<NDisplayDevice>(info, "uri", &NDisplayDevice::getURI);
 }
 
 Napi::Object NDisplayDevice::NewInstance(Napi::Env env, Napi::Value uri){

--- a/bindings/Node/libpointing/pointing/ndisplaydevice.h
+++ b/bindings/Node/libpointing/pointing/ndisplaydevice.h
@@ -18,6 +18,7 @@
 
 #include <napi.h>
 #include <pointing/pointing.h>
+#include "property.hpp"
 
 class NDisplayDevice : public Napi::ObjectWrap<NDisplayDevice>
 {

--- a/bindings/Node/libpointing/pointing/npointingdevice.cc
+++ b/bindings/Node/libpointing/pointing/npointingdevice.cc
@@ -49,17 +49,7 @@ Napi::Object NPointingDevice::Init(Napi::Env env, Napi::Object exports) {
   Napi::HandleScope scope(env);
 
   Napi::Function func = DefineClass(env, "PointingDevice", {
-    InstanceMethod("setPointingCallback", &NPointingDevice::setPointingCallback),
-    InstanceAccessor("vendorID", &NPointingDevice::getVendorID, NULL),
-    InstanceAccessor("productID", &NPointingDevice::getProductID, NULL),
-    InstanceAccessor("vendor", &NPointingDevice::getVendor, NULL),
-    InstanceAccessor("product", &NPointingDevice::getProduct, NULL),
-    InstanceAccessor("updateFrequency", &NPointingDevice::getUpdateFrequency, NULL),
-    InstanceAccessor("resolution", &NPointingDevice::getResolution, NULL),
-    InstanceAccessor("uri", &NPointingDevice::getURI, NULL),
-    InstanceAccessor("expandedUri", &NPointingDevice::getExpandedURI, NULL),
-    InstanceAccessor("active", &NPointingDevice::isActive, NULL)
-     //NULL = no setter on a read-only property.
+    InstanceMethod("setPointingCallback", &NPointingDevice::setPointingCallback)
   });
 
   constructor = Napi::Persistent(func);
@@ -82,6 +72,16 @@ NPointingDevice::NPointingDevice(const Napi::CallbackInfo& info) : Napi::ObjectW
   }
   std::string uri = info[0].ToString().Utf8Value();
   this->input = PointingDevice::create(uri);
+
+  addProperty<NPointingDevice>(info, "vendorID", &NPointingDevice::getVendorID);
+  addProperty<NPointingDevice>(info, "productID", &NPointingDevice::getProductID);
+  addProperty<NPointingDevice>(info, "vendor", &NPointingDevice::getVendor);
+  addProperty<NPointingDevice>(info, "product", &NPointingDevice::getProduct);
+  addProperty<NPointingDevice>(info, "updateFrequency", &NPointingDevice::getUpdateFrequency);
+  addProperty<NPointingDevice>(info, "resolution", &NPointingDevice::getResolution);
+  addProperty<NPointingDevice>(info, "uri", &NPointingDevice::getURI);
+  addProperty<NPointingDevice>(info, "expandedUri", &NPointingDevice::getExpandedURI);
+  addProperty<NPointingDevice>(info, "active", &NPointingDevice::isActive);
 }
 
 Napi::Object NPointingDevice::NewInstance(Napi::Env env, Napi::Value uri){

--- a/bindings/Node/libpointing/pointing/npointingdevice.h
+++ b/bindings/Node/libpointing/pointing/npointingdevice.h
@@ -18,6 +18,7 @@
 
 #include <napi.h>
 #include <pointing/pointing.h>
+#include "property.hpp"
 
 class NPointingDevice : public Napi::ObjectWrap<NPointingDevice>
 {

--- a/bindings/Node/libpointing/pointing/ntransferfunction.cc
+++ b/bindings/Node/libpointing/pointing/ntransferfunction.cc
@@ -35,13 +35,7 @@ Napi::Object NTransferFunction::Init(Napi::Env env, Napi::Object exports) {
     InstanceMethod("clearState", &NTransferFunction::clearState),
     InstanceMethod("setSubPixeling", &NTransferFunction::setSubPixeling),
     InstanceMethod("setHumanResolution", &NTransferFunction::setHumanResolution),
-    InstanceMethod("setCardinalitySize", &NTransferFunction::setCardinalitySize),
-    InstanceAccessor("uri", &NTransferFunction::getURI, NULL),
-    InstanceAccessor("subPixeling", &NTransferFunction::getSubPixeling, NULL),
-    InstanceAccessor("humanResolution", &NTransferFunction::getHumanResolution, NULL),
-    InstanceAccessor("cardinality", &NTransferFunction::getCardinality, NULL),
-    InstanceAccessor("widgetSize", &NTransferFunction::getWidgetSize, NULL),
-     //NULL = no setter on a read-only property.
+    InstanceMethod("setCardinalitySize", &NTransferFunction::setCardinalitySize)
   });
 
   constructor = Napi::Persistent(func);
@@ -71,12 +65,11 @@ NTransferFunction::NTransferFunction(const Napi::CallbackInfo& info) : Napi::Obj
   this->nInput = ninput;
   this->nOutput = noutput;
 
-  // NAN CODE:
-  //   func = new SubPixelFunction("subpixel:?isOn=false", uri, ninput->input, noutput->output);
-  //
-  // obj->nInput.Reset(info[1]);
-  // obj->nOutput.Reset(info[2]);
-  // obj->Wrap(info.This());
+  addProperty(info, "uri", &NTransferFunction::getURI);
+  addProperty(info, "subPixeling", &NTransferFunction::getSubPixeling);
+  addProperty(info, "humanResolution", &NTransferFunction::getHumanResolution);
+  addProperty(info, "cardinality", &NTransferFunction::getCardinality);
+  addProperty(info, "widgetSize", &NTransferFunction::getWidgetSize);
 }
 
 Napi::Object NTransferFunction::NewInstance(Napi::Env env, Napi::Value uri, Napi::Value input, Napi::Value output){

--- a/bindings/Node/libpointing/pointing/property.hpp
+++ b/bindings/Node/libpointing/pointing/property.hpp
@@ -1,0 +1,46 @@
+/* -*- mode: c++ -*-
+ *
+ * pointing/property.hpp
+ *
+ * Initial software
+ * Author: Etienne Orieux
+ * Copyright © Inria
+ *
+ * http://libpointing.org/
+ *
+ * This software may be used and distributed according to the terms of
+ * the GNU General Public License version 2 or any later version.
+ *
+ */
+
+#ifndef PROPERTY_H
+#define PROPERTY_H
+
+#include <napi.h>
+
+/**
+ * Adds a read-only property to a {@link Napi::ObjectWrap} subclass.
+ *
+ * @tparam T the type of subclass
+ * @param info the components of the JavaScript request
+ * @param name the name of the property
+ * @param getter the {@link Napi::InstanceGetterCallback} to call when retrieving the property
+ * @author Etienne Orieux
+ */
+template< class T >
+void addProperty(const Napi::CallbackInfo& info,
+                 const char* name,
+                 Napi::Value(T::*getter)(const Napi::CallbackInfo&))
+{
+  T* that = Napi::ObjectWrap<T>::Unwrap(info.This().As<Napi::Object>());
+  info.This().As<Napi::Object>().DefineProperty(
+       Napi::PropertyDescriptor::Accessor(info.Env(),
+                                          info.This().As<Napi::Object>(),
+                                          name,
+                                          [that, getter](const Napi::CallbackInfo& info) -> Napi::Value {
+                                            return (that->*getter)(info);
+                                          },
+                                          napi_enumerable, that));
+}
+
+#endif

--- a/bindings/Node/server/server.js
+++ b/bindings/Node/server/server.js
@@ -75,43 +75,18 @@ io.on('connection', function(socket) {
   socket.on('pointingDeviceCreate', function(uri, id) {
     var input = new pointing.PointingDevice(uri ? uri : "any:");
     objects[id] = input;
-    var input = {
-      vendorID:input.vendorID,
-      productID:input.productID,
-      vendor:input.vendor,
-      product:input.product,
-      updateFrequency:input.updateFrequency,
-      resolution:input.resolution,
-      uri:input.uri,
-      expandedUri:input.expandedUri,
-      active:input.active,
-    }
     socket.emit('pointingObjectInfo', id, input);
   });
 
   socket.on('displayDeviceCreate', function(uri, id) {
     var output = new pointing.DisplayDevice(uri ? uri : "any:");
     objects[id] = output;
-    var output = {
-      size:output.size,
-      bounds: output.bounds,
-      resolution:output.resolution,
-      refreshRate:output.refreshRate,
-      uri:output.uri
-    }
     socket.emit('pointingObjectInfo', id, output);
   });
 
   socket.on('transferFunctionCreate', function(uri, id, inputId, outputId) {
     var tf = new pointing.TransferFunction(uri, objects[inputId], objects[outputId]);
     objects[id] = tf;
-    var tf = {
-     uri:tf.uri,
-     subPixeling:tf.subPixeling,
-     humanResolution:tf.humanResolution,
-     cardinality:tf.cardinality,
-     widgetSize:tf.widgetSize
-    }
     socket.emit('pointingObjectInfo', id, tf);
   });
 


### PR DESCRIPTION
I found a much better solution compared to #30. Class properties are added using a custom template helper function documented in `property.hpp`.