### PR TITLE
windows : install library with absolute path

### DIFF
--- a/bindings/Node/libpointing/binding.gyp
+++ b/bindings/Node/libpointing/binding.gyp
@@ -46,29 +46,16 @@
 			}],
 			['OS=="win"', {
 				"link_settings": {
-					"conditions": [
-						["target_arch == 'ia32'", {
-							'libraries': [
-								'-lsetupapi',
-								'-lhid',
-								'-luser32',
-								'-ladvapi32',
-                                '../../../../pointing/Release/pointing.lib'
-							]
-						}],
-						["target_arch == 'x64'", {
-							'libraries': [
-								'-lsetupapi',
-								'-lhid',
-								'-luser32',
-								'-ladvapi32',
-								'../../../../pointing/x64/Release/pointing.lib'
-							]
-						}]
-					]
-				 },
+					'libraries': [
+						'-lsetupapi',
+						'-lhid',
+						'-luser32',
+						'-ladvapi32',
+                        'C:/Program Files/libpointing/pointing.lib'
+    				]
+    			 },
 				"include_dirs": [
-					'../../..',
+					'C:/Program Files/libpointing',
                     "<!@(node -p \"require('node-addon-api').include\")"
 				],
 				'configurations': {


### PR DESCRIPTION
installing libpointing [with chocolatey](https://chocolatey.org/packages/libpointing) puts the library in the same location : `C:/Program Files/libpointing`.