### PR TITLE
chocolatey package : corrections after moderators reviews

### DIFF
--- a/building-and-packaging/windows/libpointing.nuspec
+++ b/building-and-packaging/windows/libpointing.nuspec
@@ -3,7 +3,7 @@
   <metadata>
     <id>libpointing</id>
     <title>Libpointing</title>
-    <version>2.1.0</version>
+    <version>1.0.8</version>
     <authors>Géry Casiez, Nicolas Roussel, Izzatbek Mukhanov</authors>
     <tags>control-display gain pointer acceleration pointing transfer-functions</tags>
     <summary>An open-source cross-platform library to get raw events from pointing devices and master transfer functions</summary>

--- a/building-and-packaging/windows/libpointing.nuspec
+++ b/building-and-packaging/windows/libpointing.nuspec
@@ -5,13 +5,15 @@
     <title>Libpointing</title>
     <version>1.0.8</version>
     <authors>Géry Casiez, Nicolas Roussel, Izzatbek Mukhanov</authors>
+    <owners>Géry Casiez, Etienne Orieux</owners>
     <tags>control-display gain pointer acceleration pointing transfer-functions</tags>
     <summary>An open-source cross-platform library to get raw events from pointing devices and master transfer functions</summary>
     <releaseNotes>https://github.com/INRIA/libpointing/releases</releaseNotes>
     <docsUrl>https://github.com/INRIA/libpointing/wiki</docsUrl>
     <description>Libpointing is an open-source cross-platform library written in C++ that provides direct access to HID pointing devices and supports the design of pointing transfer functions.</description>
     <projectUrl>http://www.libpointing.org</projectUrl>
-    <packageSourceUrl>https://chocolatey.org/packages/libpointing</packageSourceUrl>
+    <licenseUrl>https://github.com/INRIA/libpointing/blob/master/LICENSE.md</licenseUrl>
+    <packageSourceUrl>https://github.com/INRIA/libpointing</packageSourceUrl>
     <requireLicenseAcceptance>false</requireLicenseAcceptance>
   </metadata>
 </package>

--- a/building-and-packaging/windows/tools/chocolateyInstall.ps1
+++ b/building-and-packaging/windows/tools/chocolateyInstall.ps1
@@ -1,4 +1,15 @@
+$url32 = 'https://github.com/INRIA/libpointing/releases/download/v1.0.8/libpointing-v1.0.8-Win32-VS2015.zip'
+$checksum32 = '78E480B64105680C34306E507C6691E085CCA08978BCCF874CBA7737ACBF1BF6'
+$url64 = 'https://github.com/INRIA/libpointing/releases/download/v1.0.8/libpointing-v1.0.8-Win64-VS2015.zip'
+$checksum64 = 'C4D79A20991E24D66C71C5B4639FBFB5EE52862B38262CA35A9751D097EEFEBE'
+
+$location = $Env:programFiles + '\libpointing\'
+
 Install-ChocolateyZipPackage -PackageName 'libpointing' `
- -Url 'https://github.com/INRIA/libpointing/releases/download/v1.0.8/libpointing-v1.0.8-Win32-VS2015.zip' `
- -UnzipLocation 'C:/Program Files/libpointing/' `
- -Url64 'https://github.com/INRIA/libpointing/releases/download/v1.0.8/libpointing-v1.0.8-Win64-VS2015.zip' `
+ -Url $url32 `
+ -UnzipLocation $location `
+ -Url64 $url64 `
+ -Checksum $checksum32 `
+ -ChecksumType 'sha256' `
+ -Checksum64 $checksum64 `
+ -ChecksumType64 'sha256' `


### PR DESCRIPTION
For any new libpointing release, 
- cd `building-and-packaging/windows`
- in `tools/chocolateyInstall.ps1` : update the url and checksum for the x32 and x64 release. The checksum can be calcultated with `openssl dgst -sha256 libpointing-vXXX-WinXX-VS2015.zip`
- increment the version number in `libpointing.nuspec`
- `rm *.nupkg` : remove any older packages.
- `cpack` : build a new `.nupkg` file.
- `cpush` : push the package to chocolatey 

This process could (should) be automated.