### PR TITLE
Revise binding.gyp to make linux more like mac

### DIFF
--- a/bindings/Node/libpointing/binding.gyp
+++ b/bindings/Node/libpointing/binding.gyp
@@ -35,14 +35,15 @@
 			}],
 			['OS=="linux"', {
 				"link_settings": {
-				'libraries': [
-				   '/usr/lib/pointing.so'
-				 ]},
+					'libraries': [
+					   '-lpointing',
+					   '-L/usr/local/lib'
+					 ]
+				 },
 				"include_dirs": [
-                   '-lpointing',
-				   '-L/usr/local/lib',
+					'/usr/local/include',
 					"<!@(node -p \"require('node-addon-api').include\")"
-				]
+				],
 			}],
 			['OS=="win"', {
 				"link_settings": {


### PR DESCRIPTION
I tried to install the Node package on Linux following instructions at https://www.npmjs.com/package/libpointing:

 * Install libpointing
 * npm install libpointing

To install libpointing, I downloaded [the latest .deb package](https://github.com/INRIA/libpointing/releases/download/v1.0.8/libpointing-1.0.8_x86_64.deb) and installed it. This installed the library to /usr/local/lib/libpointing.so.

But `npm install libpointing` failed because it couldn't find '/usr/lib/pointing.so'

This change is to bindings/Node/libpointing/binding.gyp, making the section for "OS"=="Linux" more like that for "OS"=="mac".

With this change, I am able to complete the build of the Node package, with the library at /usr/local/lib/libpointing.so, as installed by the latest .deb package.

In the meantime, a soft link from /usr/local/pointing.so to /usr/local/lib/libpointing.so allows npm install libpointing to succeed.